### PR TITLE
Pad timestamp values with leading zeros

### DIFF
--- a/src/data/database.ts
+++ b/src/data/database.ts
@@ -153,12 +153,12 @@ export const timestampToString = (timestamp: Timestamp, showTimeOnFullDate?: boo
     let hours = `${messageDate.getHours()}`;
     let minutes = `${messageDate.getMinutes()}`;
 
-    if (hours === "0") {
-        hours = "00";
+    if (hours.length === 1) {
+        hours = `0${hours}`;
     }
 
-    if (minutes === "0") {
-        minutes = "00";
+    if (minutes.length === 1) {
+        minutes = `0${minutes}`;
     }
 
     if (today.getFullYear() === messageDate.getFullYear() &&

--- a/src/data/timestampToString.test.ts
+++ b/src/data/timestampToString.test.ts
@@ -1,0 +1,15 @@
+import firebase from "firebase/app";
+import "firebase/firestore";
+import { timestampToString } from "./database";
+
+describe("timestampToString", () => {
+    it("pads single digit hours and minutes with leading zeros", () => {
+        const date = new Date();
+        date.setHours(5, 3, 0, 0);
+        const timestamp = firebase.firestore.Timestamp.fromDate(date);
+
+        const formatted = timestampToString(timestamp);
+
+        expect(formatted).toBe("05:03");
+    });
+});


### PR DESCRIPTION
## Summary
- fix timestamp formatting to pad single-digit hours/minutes
- add test for timestampToString formatting

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6895cc4fc6b0832ba7f3ee565533e66b