### PR TITLE
Fix stale auth and route update effects

### DIFF
--- a/src/components/context providers/AuthContextProvider.test.tsx
+++ b/src/components/context providers/AuthContextProvider.test.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { useAuth } from "../../contexts/AuthContext";
+import AuthContextProvider from "./AuthContextProvider";
+import database from "../../data/database";
+
+let mockAuthChangeHandler: ((user: any) => void) | undefined;
+
+jest.mock("firebase/auth", () => ({}));
+
+jest.mock("firebase/app", () => {
+  const authInstance = {
+    onAuthStateChanged: (handler: (user: any) => void) => {
+      mockAuthChangeHandler = handler;
+      return () => {};
+    },
+    setPersistence: jest.fn(() => Promise.resolve()),
+    signInWithEmailAndPassword: jest.fn(),
+    signInWithPopup: jest.fn(),
+    createUserWithEmailAndPassword: jest.fn(),
+    signOut: jest.fn(),
+  };
+
+  const auth = (() => authInstance) as any;
+
+  auth.GoogleAuthProvider = jest.fn();
+  auth.Auth = {
+    Persistence: {
+      LOCAL: "local",
+      SESSION: "session",
+    },
+  };
+
+  const firebaseMock = {
+    auth,
+  };
+
+  return {
+    __esModule: true,
+    ...firebaseMock,
+    default: firebaseMock,
+  };
+});
+
+jest.mock("../../data/database", () => ({
+  __esModule: true,
+  default: {
+    roles: {
+      get: jest.fn(),
+    },
+  },
+}));
+
+const RoleStatus = () => {
+  const { isDeveloper, isOwner, isLoggedIn } = useAuth();
+
+  return (
+    <div>
+      <span data-testid="developer">{String(isDeveloper)}</span>
+      <span data-testid="owner">{String(isOwner)}</span>
+      <span data-testid="logged-in">{String(isLoggedIn)}</span>
+    </div>
+  );
+};
+
+describe("AuthContextProvider", () => {
+  beforeEach(() => {
+    mockAuthChangeHandler = undefined;
+    jest.clearAllMocks();
+  });
+
+  it("ignores stale role results after logout", async () => {
+    let resolveDeveloperRole: (value: { users: string[] }) => void = () => {};
+
+    (database.roles.get as jest.Mock).mockImplementation((role: string) => {
+      if (role === "developer") {
+        return new Promise((resolve) => {
+          resolveDeveloperRole = resolve;
+        });
+      }
+
+      return Promise.resolve({ users: ["user-1"] });
+    });
+
+    render(
+      <AuthContextProvider>
+        <RoleStatus />
+      </AuthContextProvider>
+    );
+
+    await act(async () => {
+      mockAuthChangeHandler?.({ uid: "user-1", isAnonymous: false });
+      mockAuthChangeHandler?.(null);
+      resolveDeveloperRole({ users: ["user-1"] });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("logged-in")).toHaveTextContent("false");
+      expect(screen.getByTestId("developer")).toHaveTextContent("false");
+      expect(screen.getByTestId("owner")).toHaveTextContent("false");
+    });
+  });
+});

--- a/src/components/context providers/AuthContextProvider.tsx
+++ b/src/components/context providers/AuthContextProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import firebase from "firebase/app";
 import AuthContext from "../../contexts/AuthContext";
 
@@ -24,29 +24,42 @@ const checkForRole = async (role: string, userId: string | undefined) => {
 };
 
 export const AuthContextProvider: React.FC = ({ children }) => {
+  const roleCheckId = useRef(0);
   const [loginSource, setLoginSource] = useState<string>("");
   const [isLoggedIn, setIsLoggedIn] = useState<boolean | undefined>(undefined);
   const [user, setUser] = useState<firebase.User | null>(null);
   const [isDeveloper, setIsDeveloper] = useState(false);
   const [isOwner, setIsOwner] = useState(false);
 
-  const checkRoles = async (userId: string | undefined) => {
+  const checkRoles = async (userId: string | undefined, checkId: number) => {
     const isDeveloper = await checkForRole("developer", userId);
     console.log(isDeveloper ? "Is developer" : "Is not a developer");
+
+    if (roleCheckId.current !== checkId) {
+      return;
+    }
 
     setIsDeveloper(isDeveloper);
 
     const isOwner = await checkForRole("owner", userId);
     console.log(isOwner ? "Is owner" : "Is not an owner");
 
+    if (roleCheckId.current !== checkId) {
+      return;
+    }
+
     setIsOwner(isOwner);
   };
 
   useEffect(() => {
     const unsubscribe = firebase.auth().onAuthStateChanged(function (newUser) {
+      roleCheckId.current += 1;
+
       if (newUser && !newUser.isAnonymous) {
+        const currentRoleCheckId = roleCheckId.current;
+
         setUser(newUser);
-        checkRoles(newUser?.uid).then();
+        checkRoles(newUser?.uid, currentRoleCheckId).then();
         setIsLoggedIn(true);
       } else {
         setIsLoggedIn(false);

--- a/src/components/layouts/pages/PageLayout.test.tsx
+++ b/src/components/layouts/pages/PageLayout.test.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+import PageLayout from "./PageLayout";
+
+const mockSetCurrentPageTitle = jest.fn();
+
+jest.mock("../../../hooks/useNavigation", () => ({
+  __esModule: true,
+  default: () => ({
+    setCurrentPageTitle: mockSetCurrentPageTitle,
+  }),
+}));
+
+describe("PageLayout", () => {
+  beforeEach(() => {
+    mockSetCurrentPageTitle.mockClear();
+  });
+
+  it("updates the page title only when the title changes", async () => {
+    const { rerender } = render(
+      <PageLayout title="Contact">Contact content</PageLayout>
+    );
+
+    await waitFor(() => expect(mockSetCurrentPageTitle).toHaveBeenCalledTimes(1));
+    expect(mockSetCurrentPageTitle).toHaveBeenLastCalledWith("Contact");
+
+    rerender(<PageLayout title="Contact">Updated contact content</PageLayout>);
+
+    expect(mockSetCurrentPageTitle).toHaveBeenCalledTimes(1);
+
+    rerender(<PageLayout title="Messages">Messages content</PageLayout>);
+
+    await waitFor(() => expect(mockSetCurrentPageTitle).toHaveBeenCalledTimes(2));
+    expect(mockSetCurrentPageTitle).toHaveBeenLastCalledWith("Messages");
+  });
+});

--- a/src/components/layouts/pages/PageLayout.tsx
+++ b/src/components/layouts/pages/PageLayout.tsx
@@ -12,11 +12,11 @@ const PageLayout: React.FC<PageLayoutProps> = ({
   title,
   ...props
 }) => {
-  const navigation = useNavigation();
+  const { setCurrentPageTitle } = useNavigation();
 
   useEffect(() => {
-    navigation.setCurrentPageTitle(title);
-  });
+    setCurrentPageTitle(title);
+  }, [setCurrentPageTitle, title]);
 
   // Check if className contains padding classes to determine if we should apply custom padding
   const hasCustomPadding = className?.includes('p-') || className?.includes('pt-') || className?.includes('pb-') || className?.includes('px-') || className?.includes('py-');

--- a/src/components/layouts/pages/general/AskMeAnything/context.tsx
+++ b/src/components/layouts/pages/general/AskMeAnything/context.tsx
@@ -306,16 +306,18 @@ export const useAskMeAnythingContext = ({
   ]);
 
   useEffect(() => {
-    window.onbeforeunload = function () {
-      console.log("onbeforeunload");
-      if (messageCount === 0 && thread_id) {
-        handleEndConversation();
-      }
-      return true;
+    if (messageCount !== 0 || !thread_id) {
+      return;
+    }
+
+    const handleBeforeUnload = () => {
+      handleEndConversation(thread_id);
     };
 
+    window.addEventListener("beforeunload", handleBeforeUnload);
+
     return () => {
-      window.onbeforeunload = null;
+      window.removeEventListener("beforeunload", handleBeforeUnload);
     };
   }, [handleEndConversation, messageCount, thread_id]);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Prevent stale Firebase role checks from restoring developer/owner flags after logout or account changes.
- Limit page-title synchronization to actual title changes to avoid repeated context updates.
- Replace the assistant `onbeforeunload` return handler with a scoped listener that does cleanup without forcing a leave confirmation.
- Add focused React Testing Library coverage for the route-title effect and auth stale-result race.

### Testing
- `CI=true npm test -- --runInBand --watchAll=false`
- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79f9b501-0f94-40b9-819c-d581bf9e986f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79f9b501-0f94-40b9-819c-d581bf9e986f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

