### PR TITLE
Redesign portfolio with "Precision / AI" design system

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="light">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
@@ -7,7 +7,29 @@
     <meta name="theme-color" content="#E5E7EB" />
     <meta
       name="description"
-      content="Aboo Daniel - Software Development"
+      content="Daniel Aboo — Prompt Engineer II at LivePerson. Designing AI agents, prompt architectures and conversational AI that move business metrics."
+    />
+    <!-- Set the theme before first paint to avoid a flash of the wrong mode -->
+    <script>
+      (function () {
+        try {
+          var saved = localStorage.getItem("da-theme");
+          var mode =
+            saved === "light" || saved === "dark"
+              ? saved
+              : window.matchMedia("(prefers-color-scheme: dark)").matches
+              ? "dark"
+              : "light";
+          document.documentElement.setAttribute("data-theme", mode);
+        } catch (e) {}
+      })();
+    </script>
+    <!-- Geist + Geist Mono — design-system typefaces -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700;800&family=Geist+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/images/logo.png" />
     <!--
@@ -24,9 +46,9 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Aboo Daniel</title>
+    <title>Daniel Aboo — Prompt Engineer & Full-Stack Developer</title>
   </head>
-  <body class="bg-background-light dark:bg-background-dark">
+  <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <!--

--- a/src/App.styled.ts
+++ b/src/App.styled.ts
@@ -3,7 +3,7 @@ import styled from "styled-components";
 export const AppContainer = styled.div`
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  min-height: 100vh;
 `;
 
 export const AppContent = styled.div`

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { BrowserRouter, Route, Switch } from "react-router-dom";
 
 // Page imports
-import NewHomePageLayout from "./components/layouts/pages/general/NewHomePageLayout";
+import HomePageLayout from "./components/layouts/pages/general/HomePageLayout";
 import MaintenancePageLayout from "./components/layouts/pages/general/MaintenancePageLayout";
 import ExperiencePageLayout from "./components/layouts/pages/general/ExperiencePageLayout";
 import ContactPageLayout from "./components/layouts/pages/general/ContactPageLayout";
@@ -14,9 +14,7 @@ import MessagesPageLayout from "./components/layouts/pages/development and admin
 import AskMeAnythingLayout from "./components/layouts/pages/general/AskMeAnything";
 
 // Main elements imports
-import PageNavigatorBar from "./components/molecules/general/PageNavigatorBar";
-import PageNavigatorBarLink from "./components/atoms/buttons and links/PageNavigatorBarLink";
-import Footer from "./components/molecules/general/Footer";
+import Navbar from "./components/molecules/general/Navbar";
 import SkipLink from "./components/atoms/utilities/SkipLink";
 
 // Hooks
@@ -27,9 +25,9 @@ import NavigationProvider from "./components/context providers/NavigationProvide
 import { AppContainer, AppContent } from "./App.styled";
 
 function AppWithRouter() {
-  // Maintenance flag - set to true to show maintenance page instead of old home page
+  // Maintenance flag - set to true to show maintenance page instead of the home page
   const MAINTENANCE_MODE = process.env.REACT_APP_MAINTENANCE_MODE === "true";
-  
+
   // Handle focus management on route changes
   useFocusOnRouteChange();
 
@@ -37,23 +35,14 @@ function AppWithRouter() {
     <NavigationProvider>
       <AppContainer>
         <SkipLink />
-        <PageNavigatorBar>
-          <PageNavigatorBarLink to="/">Home</PageNavigatorBarLink>
-          {/* <PageNavigatorBarLink to="/experience">
-                  Experience
-              </PageNavigatorBarLink> */}
-          <PageNavigatorBarLink to="/assistant">
-            My Assistant (Beta)
-          </PageNavigatorBarLink>
-          <PageNavigatorBarLink to="/contact">Contact</PageNavigatorBarLink>
-        </PageNavigatorBar>
+        <Navbar />
         <AppContent as="main" id="main-content" tabIndex={-1}>
           <Switch>
             <Route exact path="/">
-              <NewHomePageLayout />
+              <HomePageLayout />
             </Route>
             <Route exact path="/home">
-              <NewHomePageLayout />
+              <HomePageLayout />
             </Route>
             <Route exact path="/maintenance">
               <MaintenancePageLayout showMaintenance={MAINTENANCE_MODE} />
@@ -87,7 +76,6 @@ function AppWithRouter() {
             </Route>
           </Switch>
         </AppContent>
-        <Footer isInsideMenu={false} />
       </AppContainer>
     </NavigationProvider>
   );

--- a/src/components/layouts/pages/general/AskMeAnything/index.tsx
+++ b/src/components/layouts/pages/general/AskMeAnything/index.tsx
@@ -1,13 +1,18 @@
-import React, { useEffect, useRef, useState } from "react";
-import PageLayout from "../../PageLayout";
+import React, { useEffect, useRef } from "react";
+import ReactMarkdown from "react-markdown";
+import TextareaAutosize from "react-textarea-autosize";
 
 import { useAuth } from "../../../../../contexts/AuthContext";
-import * as styles from "./AskmeAnything.styles";
 import { useAskMeAnythingContext } from "./context";
 
+const suggestions = [
+  { label: "What does he do now?", q: "What does Daniel do at LivePerson?" },
+  { label: "Built with AI?", q: "What has Daniel built with LLMs and AI agents?" },
+  { label: "His background", q: "Tell me about Daniel's experience and career" },
+  { label: "Hire him", q: "How can I contact Daniel for consulting?" },
+];
+
 const AskMeAnythingPage: React.FC = () => {
-  const minTextareaRows = 2;
-  const maxTextareaRows = 5;
   const maxMessageLength = parseInt(
     process.env.REACT_APP_MAX_MESSAGE_LENGTH ?? "0"
   );
@@ -22,7 +27,6 @@ const AskMeAnythingPage: React.FC = () => {
     maxMessages,
     messageCount,
     thread_id,
-    assistant_id,
     setMessage,
     handleSendMessage,
     handleStartConversation,
@@ -31,10 +35,9 @@ const AskMeAnythingPage: React.FC = () => {
 
   const threadIdRef = useRef(thread_id);
   const messagesCountRef = useRef(messageCount);
+  const chatRef = useRef<HTMLDivElement>(null);
 
-  const [copiedMessageIndex, setCopiedMessageIndex] = useState<number | null>(
-    null
-  );
+  const canSend = messageCount < maxMessages && !!thread_id;
 
   const handleInputChange: React.ChangeEventHandler<HTMLTextAreaElement> = (
     event
@@ -49,21 +52,22 @@ const AskMeAnythingPage: React.FC = () => {
   ) => {
     if (event.key === "Enter" && !event.shiftKey) {
       event.preventDefault();
-      handleSendMessage();
+      if (canSend) handleSendMessage();
     }
   };
 
   const handleSubmit: React.FormEventHandler<HTMLFormElement> = (event) => {
     event.preventDefault();
-    if (messageCount < maxMessages && thread_id) {
+    if (canSend) {
       handleSendMessage();
     } else {
       handleStartConversation(isLoggedIn && isOwner);
     }
   };
 
-  const copyToClipboard = (message: string) => {
-    navigator.clipboard.writeText(message);
+  const handleSuggestion = (q: string) => {
+    setMessage(q);
+    messageInputRef.current?.focus();
   };
 
   useEffect(() => {
@@ -72,6 +76,7 @@ const AskMeAnythingPage: React.FC = () => {
   }, [thread_id, messageCount]);
 
   useEffect(() => {
+    document.title = "Daniel Aboo — AI Assistant";
     handleStartConversation(isLoggedIn && isOwner);
 
     return () => {
@@ -82,146 +87,115 @@ const AskMeAnythingPage: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  return (
-    <PageLayout title="Home">
-      <styles.PageContainer>
-        <styles.MainContainer>
-          <styles.PageTitle>Ask me anything!</styles.PageTitle>
-          {isLoggedIn &&
-            isDeveloper &&
-            new URLSearchParams(window.location.search).get("debug_mode") ===
-              "true" && (
-              <styles.developerInformation>
-                <p>
-                  <b>Assistant:</b> {assistant_id}
-                </p>
-                <p>
-                  <b>Thread:</b> {thread_id}
-                </p>
-                {thread_id ? (
-                  <button onClick={() => handleEndConversation()}>
-                    End Conversation
-                  </button>
-                ) : (
-                  <>
-                    <button
-                      onClick={() =>
-                        handleStartConversation(isLoggedIn && isOwner)
-                      }
-                    >
-                      Start Conversation
-                    </button>
-                    {isLoggedIn && isOwner && (
-                      <button onClick={() => handleStartConversation(false)}>
-                        Start Conversation with General Assistant
-                      </button>
-                    )}
-                  </>
-                )}
-              </styles.developerInformation>
-            )}
-          {isOwner ? (
-            <p>
-              Hi Daniel, I'm your personal assistant. How can I help you today?
-            </p>
-          ) : (
-            <styles.CenteredText>
-              You can ask me anything about Daniel Aboo. I will try to answer
-              your questions as best as I can 😁 <br />
-              <br />I can also inform Daniel about anything, if you have any
-              questions to him directly.
-            </styles.CenteredText>
-          )}
-          {/* List messages */}
-          <styles.messagesList>
-            {messages.map((message, index) => {
-              const MessageComponent =
-                message.role === "user"
-                  ? styles.UserMessage
-                  : styles.AssistantMessage;
-              return (
-                <MessageComponent key={index}>
-                  <styles.TextMarkdown>{message.message}</styles.TextMarkdown>
-                  {message.role !== "user" &&
-                    (copiedMessageIndex !== index ? (
-                      <styles.copyButton
-                        onClick={() => {
-                          copyToClipboard(message.message);
-                          setCopiedMessageIndex(index);
-                          setTimeout(() => setCopiedMessageIndex(null), 2000);
-                        }}
-                        style={{ cursor: "pointer" }}
-                        title="Copy to clipboard"
-                      >
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          width="16"
-                          height="16"
-                          fill="currentColor"
-                          viewBox="0 0 16 16"
-                        >
-                          <path
-                            fill-rule="evenodd"
-                            d="M4 2a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2zm2-1a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1zM2 5a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1v-1h1v1a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h1v1z"
-                          />
-                        </svg>
-                      </styles.copyButton>
-                    ) : (
-                      <styles.copiedText>
-                        Copied to clipboard!
-                      </styles.copiedText>
-                    ))}
-                </MessageComponent>
-              );
-            })}
-            {/* If loading and last message is with .role == "user", add a message with three dots loader animated */}
-            {isLoading && messages[messages.length - 1]?.role === "user" && (
-              <styles.dotsContainer>
-                <styles.dots />
-              </styles.dotsContainer>
-            )}
-          </styles.messagesList>
-          {/* Add messages/maxMessages */}
-          {!isDeveloper && (
-            <styles.MessageCount>
-              {messageCount}/{maxMessages}
-            </styles.MessageCount>
-          )}
-          {/* Here show input for the user and on the right a send button which triggers the handleSendMessage */}
-          <styles.Form
-            onSubmit={handleSubmit}
-            className={isDeveloper ? "isDeveloper" : ""}
-          >
-            <styles.messageInput
-              onChange={handleInputChange}
-              onKeyDown={handleKeyDown}
-              disabled={isLoading || messageCount >= maxMessages || !thread_id}
-              value={message}
-              ref={messageInputRef}
-              minRows={minTextareaRows}
-              maxRows={maxTextareaRows}
-            />
-            {!isOwner && (
-              <p>
-                {message.length}/{maxMessageLength}
-              </p>
-            )}
+  // keep the chat scrolled to the latest message
+  useEffect(() => {
+    if (chatRef.current) {
+      chatRef.current.scrollTop = chatRef.current.scrollHeight;
+    }
+  }, [messages, isLoading]);
 
-            {isLoading ? (
-              <styles.dotsContainer className="buttonLoader">
-                <styles.dots />
-              </styles.dotsContainer>
-            ) : (
-              <styles.submitButton type="submit" disabled={isLoading}>
-                {messageCount >= maxMessages || !thread_id
-                  ? "Start new conversation"
-                  : "Send"}
-              </styles.submitButton>
-            )}
-          </styles.Form>
-        </styles.MainContainer>
-      </styles.PageContainer>
-    </PageLayout>
+  const showTyping =
+    isLoading && messages[messages.length - 1]?.role === "user";
+
+  return (
+    <div className="asst-wrap asst-page">
+      <div className="asst-head">
+        <span className="asst-badge">
+          <span className="dot" /> Online · Beta
+        </span>
+        <h1 className="asst-title">Ask me anything</h1>
+        <p className="asst-sub">
+          {isOwner
+            ? "Hi Daniel, I'm your personal assistant. How can I help you today?"
+            : "A small demo of what I build. This assistant knows Daniel's background — or it can pass a message straight to him."}
+        </p>
+      </div>
+
+      <div className="chat" id="chat" aria-live="polite" ref={chatRef}>
+        {messages.map((m, index) => {
+          const isUser = m.role === "user";
+          return (
+            <div className={`msg ${isUser ? "user" : "bot"}`} key={index}>
+              <span className="avatar">{isUser ? "You" : "DA"}</span>
+              <div className="bubble">
+                {isUser ? (
+                  <p>{m.message}</p>
+                ) : (
+                  <ReactMarkdown>{m.message}</ReactMarkdown>
+                )}
+              </div>
+            </div>
+          );
+        })}
+        {showTyping && (
+          <div className="typing" aria-label="Assistant is typing">
+            <span />
+            <span />
+            <span />
+          </div>
+        )}
+      </div>
+
+      <div className="composer" id="composer-region">
+        {messages.length === 0 && (
+          <div className="suggest" id="suggest">
+            {suggestions.map((s) => (
+              <button
+                key={s.q}
+                type="button"
+                className="suggest-chip"
+                disabled={!thread_id || isLoading}
+                onClick={() => handleSuggestion(s.q)}
+              >
+                {s.label}
+              </button>
+            ))}
+          </div>
+        )}
+        <form className="composer-inner" id="composer" onSubmit={handleSubmit}>
+          <TextareaAutosize
+            id="msg-input"
+            minRows={1}
+            maxRows={6}
+            placeholder="Ask about Daniel's work, projects, skills…"
+            aria-label="Message"
+            value={message}
+            ref={messageInputRef}
+            onChange={handleInputChange}
+            onKeyDown={handleKeyDown}
+            disabled={isLoading || !canSend}
+          />
+          <button
+            className="send-btn"
+            id="send-btn"
+            type="submit"
+            aria-label={canSend ? "Send" : "Start new conversation"}
+            disabled={isLoading}
+          >
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M12 19V5M5 12l7-7 7 7" />
+            </svg>
+          </button>
+        </form>
+        <div className="composer-meta">
+          <span className="disclaimer">
+            {canSend
+              ? "Demo · responses are illustrative"
+              : "Conversation ended — send to start a new one"}
+          </span>
+          <span id="counter">
+            {messageCount} / {maxMessages}
+          </span>
+        </div>
+      </div>
+    </div>
   );
 };
 

--- a/src/components/layouts/pages/general/ContactPageLayout.tsx
+++ b/src/components/layouts/pages/general/ContactPageLayout.tsx
@@ -1,128 +1,284 @@
-import React, { useState, useEffect } from "react";
-import PageLayout from "../PageLayout";
-import TextInput from "../../../atoms/input/TextInput";
-import TextAreaInput from "../../../atoms/input/TextAreaInput";
+import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import validator from "validator";
 import { useAuth } from "../../../../contexts/AuthContext";
 import database, { Timestamp } from "../../../../data/database";
-import Button, { ButtonSize } from "../../../atoms/buttons and links/Button";
-import {
-  ContactContainer,
-  ContactTitle,
-  ContactForm,
-  RequiredFieldsText,
-  RequiredAsterisk,
-  InformationMessage,
-  ErrorMessage,
-  SubmitButtonContainer,
-} from "./ContactPageLayout.styled";
+import PortfolioFooter from "../../../molecules/general/PortfolioFooter";
+import useScrollReveal from "../../../../hooks/useScrollReveal";
+
+type FieldName = "name" | "email" | "subject" | "message";
+
+const MailIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7">
+    <rect x="3" y="5" width="18" height="14" rx="2" />
+    <path d="m3 7 9 6 9-6" />
+  </svg>
+);
+
+const PhoneIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7">
+    <path d="M22 16.9v3a2 2 0 0 1-2.2 2 19.8 19.8 0 0 1-8.6-3 19.5 19.5 0 0 1-6-6 19.8 19.8 0 0 1-3-8.6A2 2 0 0 1 4.1 2h3a2 2 0 0 1 2 1.7c.1 1 .4 1.9.7 2.8a2 2 0 0 1-.5 2.1L8.1 9.9a16 16 0 0 0 6 6l1.3-1.3a2 2 0 0 1 2.1-.4c.9.3 1.8.6 2.8.7a2 2 0 0 1 1.7 2z" />
+  </svg>
+);
+
+const LinkedInIcon = () => (
+  <svg viewBox="0 0 24 24" fill="currentColor">
+    <path d="M4.98 3.5A2.5 2.5 0 1 1 5 8.5a2.5 2.5 0 0 1 0-5zM3 9h4v12H3zM10 9h3.8v1.7h.05c.53-1 1.83-2.05 3.77-2.05 4.03 0 4.78 2.65 4.78 6.1V21h-4v-5.3c0-1.27-.02-2.9-1.77-2.9s-2.04 1.38-2.04 2.8V21h-4z" />
+  </svg>
+);
 
 const ContactPageLayout: React.FC = () => {
-  const [email, setEmail] = useState("");
   const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
   const [subject, setSubject] = useState("");
   const [message, setMessage] = useState("");
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [information, setInformation] = useState<string | null>(null);
+  const [invalid, setInvalid] = useState<Record<FieldName, boolean>>({
+    name: false,
+    email: false,
+    subject: false,
+    message: false,
+  });
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [sent, setSent] = useState(false);
   const auth = useAuth();
+
+  useScrollReveal();
+
+  useEffect(() => {
+    document.title = "Daniel Aboo — Contact";
+  }, []);
 
   useEffect(() => {
     if (auth.isLoggedIn) {
       setEmail(auth.user?.email ?? "");
       setName(auth.user?.displayName ?? "");
-
-      setInformation(
-        "Some fields were filled in for you. You may edit them if you want."
-      );
     }
   }, [auth.isLoggedIn, auth.user]);
 
+  const clearInvalid = (field: FieldName) =>
+    setInvalid((prev) => ({ ...prev, [field]: false }));
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    console.log(`${name} (${email}) submitted a message: "${message}"`);
-    setErrorMessage(null);
-    setInformation(null);
+    setSubmitError(null);
 
-    if (email.length === 0) {
-      setErrorMessage("Email is required!");
-    } else if (!validator.isEmail(email)) {
-      setErrorMessage(
-        "Email is badly formatted! Example email: email@example.com"
-      );
-    } else if (name.length === 0) {
-      setErrorMessage("Name is required!");
-    } else if (subject.length === 0) {
-      setErrorMessage("Subject is required!");
-    } else if (message.length === 0) {
-      setErrorMessage("Message is required!");
-    } else {
-      database.messages
-        .post({
-          timestamp: Timestamp.now(),
-          email,
-          name,
-          subject,
-          message,
-        })
-        .then((_) => {
-          setInformation("Message sent!");
-        })
-        .catch((error) => {
-          setErrorMessage(error.message);
-        });
+    const bad: Record<FieldName, boolean> = {
+      name: name.trim().length === 0,
+      email: !validator.isEmail(email.trim()),
+      subject: subject.trim().length === 0,
+      message: message.trim().length === 0,
+    };
+    setInvalid(bad);
+
+    if (bad.name || bad.email || bad.subject || bad.message) {
+      return;
     }
+
+    database.messages
+      .post({
+        timestamp: Timestamp.now(),
+        email,
+        name,
+        subject,
+        message,
+      })
+      .then(() => {
+        setSent(true);
+      })
+      .catch((error) => {
+        setSubmitError(error.message);
+      });
   };
 
   return (
-    <PageLayout title="Contact">
-      <ContactContainer>
-        <ContactTitle>Contact</ContactTitle>
-        <ContactForm onSubmit={handleSubmit}>
-          <TextInput
-            label="Email"
-            name="email"
-            value={email}
-            onChange={setEmail}
-            required
-          />
-          <TextInput
-            label="Name"
-            name="name"
-            value={name}
-            onChange={setName}
-            required
-          />
-          <TextInput
-            label="Subject"
-            name="subject"
-            value={subject}
-            onChange={setSubject}
-            required
-          />
-          <TextAreaInput
-            label="Message"
-            name="message"
-            value={message}
-            onChange={setMessage}
-            required
-          />
-          <RequiredFieldsText>
-            <RequiredAsterisk>*</RequiredAsterisk> Required fields
-          </RequiredFieldsText>
-          {information && (
-            <InformationMessage>{information}</InformationMessage>
-          )}
-          {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
-          <SubmitButtonContainer>
-            <Button
-              label="submit"
-              size={ButtonSize.bigFullWidth}
-              submit={true}
-            />
-          </SubmitButtonContainer>
-        </ContactForm>
-      </ContactContainer>
-    </PageLayout>
+    <>
+      <div className="wrap contact-page">
+        <div className="contact-grid">
+          {/* LEFT */}
+          <div className="contact-left">
+            <span className="kicker reveal in">
+              <span className="idx">✳</span> — Contact
+            </span>
+            <h1 className="reveal in" data-delay="1">
+              Let's build something.
+            </h1>
+            <p className="lead reveal in" data-delay="2">
+              Have an AI project, need prompt-engineering help, or just want to
+              talk shop about conversational AI? Drop a line — I read every
+              message.
+            </p>
+            <div className="contact-status reveal in" data-delay="2">
+              <span className="dot" /> Available for select consulting
+            </div>
+
+            <div className="contact-methods reveal in" data-delay="3">
+              <a className="method" href="mailto:me@aboodaniel.pl">
+                <span className="m-ico">
+                  <MailIcon />
+                </span>
+                <span>
+                  <span className="m-label">Email</span>
+                  <span className="m-value">me@aboodaniel.pl</span>
+                </span>
+              </a>
+              <a className="method" href="tel:+48601951169">
+                <span className="m-ico">
+                  <PhoneIcon />
+                </span>
+                <span>
+                  <span className="m-label">Phone</span>
+                  <span className="m-value">+48 601 951 169</span>
+                </span>
+              </a>
+              <a
+                className="method"
+                href="https://www.linkedin.com/in/danielaboo"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <span className="m-ico">
+                  <LinkedInIcon />
+                </span>
+                <span>
+                  <span className="m-label">Social</span>
+                  <span className="m-value">LinkedIn</span>
+                </span>
+              </a>
+            </div>
+          </div>
+
+          {/* RIGHT: FORM */}
+          <div className="contact-form-card card reveal" data-delay="1">
+            {!sent ? (
+              <form onSubmit={handleSubmit} noValidate>
+                <div className="field-row">
+                  <div className={`field${invalid.name ? " invalid" : ""}`}>
+                    <label htmlFor="c-name">
+                      Name <span className="req">*</span>
+                    </label>
+                    <input
+                      type="text"
+                      id="c-name"
+                      name="name"
+                      placeholder="Your name"
+                      autoComplete="name"
+                      value={name}
+                      onChange={(e) => {
+                        setName(e.target.value);
+                        clearInvalid("name");
+                      }}
+                    />
+                    <div className="field-error">Please enter your name.</div>
+                  </div>
+                  <div className={`field${invalid.email ? " invalid" : ""}`}>
+                    <label htmlFor="c-email">
+                      Email <span className="req">*</span>
+                    </label>
+                    <input
+                      type="email"
+                      id="c-email"
+                      name="email"
+                      placeholder="you@example.com"
+                      autoComplete="email"
+                      value={email}
+                      onChange={(e) => {
+                        setEmail(e.target.value);
+                        clearInvalid("email");
+                      }}
+                    />
+                    <div className="field-error">
+                      Please enter a valid email.
+                    </div>
+                  </div>
+                </div>
+                <div className={`field${invalid.subject ? " invalid" : ""}`}>
+                  <label htmlFor="c-subject">
+                    Subject <span className="req">*</span>
+                  </label>
+                  <input
+                    type="text"
+                    id="c-subject"
+                    name="subject"
+                    placeholder="What's this about?"
+                    value={subject}
+                    onChange={(e) => {
+                      setSubject(e.target.value);
+                      clearInvalid("subject");
+                    }}
+                  />
+                  <div className="field-error">Please add a subject.</div>
+                </div>
+                <div className={`field${invalid.message ? " invalid" : ""}`}>
+                  <label htmlFor="c-message">
+                    Message <span className="req">*</span>
+                  </label>
+                  <textarea
+                    id="c-message"
+                    name="message"
+                    placeholder="Tell me a little about your project or question…"
+                    value={message}
+                    onChange={(e) => {
+                      setMessage(e.target.value);
+                      clearInvalid("message");
+                    }}
+                  />
+                  <div className="field-error">Please write a message.</div>
+                </div>
+                {submitError && (
+                  <div
+                    className="field-error"
+                    style={{ display: "block", marginBottom: "1rem" }}
+                  >
+                    {submitError}
+                  </div>
+                )}
+                <div className="form-foot">
+                  <span className="req-note">
+                    <span className="req">*</span> Required fields
+                  </span>
+                  <button
+                    type="submit"
+                    className="btn btn-primary submit-btn"
+                    data-magnetic
+                  >
+                    Send message <span className="arrow">→</span>
+                  </button>
+                </div>
+              </form>
+            ) : (
+              <div className="form-success show">
+                <div className="success-ring">
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2.2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M20 6 9 17l-5-5" />
+                  </svg>
+                </div>
+                <h3>Message sent</h3>
+                <p>
+                  Thanks for reaching out — I'll get back to you soon. In the
+                  meantime, feel free to explore the rest of the site.
+                </p>
+                <Link
+                  className="btn btn-ghost"
+                  to="/"
+                  style={{ marginTop: "0.6rem" }}
+                >
+                  Back to home
+                </Link>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <PortfolioFooter variant="minimal" />
+    </>
   );
 };
 

--- a/src/components/layouts/pages/general/HomePageLayout.tsx
+++ b/src/components/layouts/pages/general/HomePageLayout.tsx
@@ -1,0 +1,300 @@
+import React, { useEffect } from "react";
+import { Link } from "react-router-dom";
+import HeroCanvas from "../../../molecules/general/HeroCanvas";
+import PortfolioFooter from "../../../molecules/general/PortfolioFooter";
+import useScrollReveal from "../../../../hooks/useScrollReveal";
+
+const marqueeItems = [
+  "LivePerson",
+  "Blue Owl",
+  "BrainGym.AI",
+  "Usprawniacze Firm",
+  "Sigbar",
+  "Odyssey Momentum",
+  "Bank Millennium",
+  "Univ. of Groningen",
+];
+
+const capabilities = [
+  {
+    num: "A1",
+    title: "AI Agent Development",
+    body: "Prompt architectures and autonomous, tool-using agents that handle real customer conversations — designed, evaluated and shipped to production at LivePerson.",
+    tags: ["Agents", "Prompt design", "Conversational AI"],
+  },
+  {
+    num: "A2",
+    title: "Machine Learning & NLP",
+    body: "Grounded in AI fundamentals from Groningen — neural networks, computer vision, NLP — applied to making language models reliable, measurable and safe.",
+    tags: ["LLMs", "NLP", "Evaluation"],
+  },
+  {
+    num: "A3",
+    title: "Front-End Engineering",
+    body: "Fast, polished React interfaces — from token-gated social UI on Odyssey Momentum to high-performance Shopify storefronts with Outsmartly at Blue Owl.",
+    tags: ["React", "TypeScript", "Module Federation"],
+  },
+  {
+    num: "A4",
+    title: "Process Automation",
+    body: "Consulting work that removes manual toil — automating operations and embedding AI agents into the sales and support flows of real businesses.",
+    tags: ["Automation", "Integrations", "Consulting"],
+  },
+];
+
+const work = [
+  {
+    idx: "01",
+    title: "Conversational AI agents",
+    desc: "Prompt architectures & agents for global brands as Prompt Engineer II.",
+    tags: ["LivePerson", "2024 — now"],
+  },
+  {
+    idx: "02",
+    title: "AI-powered learning platform",
+    desc: "GPT prompt pipelines generating personalised learning at BrainGym.AI.",
+    tags: ["BrainGym.AI", "GPT"],
+  },
+  {
+    idx: "03",
+    title: "Dynamic plugin system",
+    desc: "Module Federation + craco wrapper letting devs ship Momentum plugins with zero config.",
+    tags: ["Module Federation", "React"],
+  },
+  {
+    idx: "04",
+    title: "SteelProfil sales agent",
+    desc: "Customer-facing AI agent giving instant quotations & company info.",
+    tags: ["Usprawniacze", "Agents"],
+  },
+  {
+    idx: "05",
+    title: "Odyssey Momentum metaverse",
+    desc: "Social UI, Stage Mode & token-gated access; refactor to MobX.",
+    tags: ["Sigbar", "React · MobX"],
+  },
+  {
+    idx: "06",
+    title: "Goodie — iOS loyalty platform",
+    desc: "Swift app for discounts & loyalty; where the clean-code habit started.",
+    tags: ["Bank Millennium", "Swift"],
+  },
+];
+
+const HomePageLayout: React.FC = () => {
+  useScrollReveal();
+
+  useEffect(() => {
+    document.title = "Daniel Aboo — Prompt Engineer & Full-Stack Developer";
+  }, []);
+
+  return (
+    <>
+      {/* HERO */}
+      <section className="hero">
+        <HeroCanvas />
+        <div className="hero-fade" />
+        <div className="wrap hero-inner">
+          <div className="status hero-status reveal in">
+            <span className="dot" /> Available for select AI &amp; product
+            consulting
+          </div>
+          <h1 className="display hero-name reveal in" data-delay="1">
+            Daniel&nbsp;Aboo
+          </h1>
+          <p className="hero-role reveal in" data-delay="2">
+            <span className="accent-text">Prompt Engineer II</span> @ LivePerson
+            — building AI agents &amp; full-stack products.
+          </p>
+          <p className="lead hero-lead reveal in" data-delay="3">
+            I design and ship conversational AI — prompt architectures,
+            autonomous agents and the interfaces around them — that turn
+            frontier models into measurable business outcomes.
+          </p>
+          <div className="hero-actions reveal in" data-delay="4">
+            <Link className="btn btn-primary" data-magnetic to="/contact">
+              Start a project <span className="arrow">→</span>
+            </Link>
+            <Link className="btn btn-ghost" to="/cv">
+              View full CV
+            </Link>
+          </div>
+        </div>
+        <div className="hero-scroll reveal in" data-delay="5">
+          <span>SCROLL</span>
+          <span className="line" />
+        </div>
+      </section>
+
+      {/* MARQUEE */}
+      <div className="marquee" aria-hidden="true">
+        <div className="marquee-track">
+          {[...marqueeItems, ...marqueeItems].map((item, i) => (
+            <React.Fragment key={i}>
+              <span>{item}</span>
+              <span className="sep">/</span>
+            </React.Fragment>
+          ))}
+        </div>
+      </div>
+
+      {/* ABOUT */}
+      <section className="section-pad" id="about">
+        <div className="wrap about-grid">
+          <div className="about-left reveal">
+            <span className="kicker">
+              <span className="idx">01</span> — About
+            </span>
+            <h2 className="section-title">
+              I build AI that earns its place in the product.
+            </h2>
+            <div className="about-portrait card">
+              <img src="/images/me.jpg" alt="Daniel Aboo" />
+            </div>
+          </div>
+          <div className="about-right">
+            <p className="lead reveal">
+              I'm a prompt engineer and full-stack developer based in Poland. At
+              LivePerson I design prompt architectures and autonomous agents for
+              global brands — the kind that hold a real conversation and quietly
+              do the work behind it.
+            </p>
+            <p className="about-body reveal" data-delay="1">
+              My path was hands-on from the start: an early iOS role at Bank
+              Millennium, a BSc in Artificial Intelligence at the University of
+              Groningen, then years shipping iOS/tvOS, AR and React products at
+              Sigbar and on the Odyssey Momentum metaverse platform.
+            </p>
+            <p className="about-body reveal" data-delay="2">
+              From there I moved into consulting — automating operations and
+              building customer-facing AI agents for companies like SteelProfil
+              — then into prompt engineering proper at BrainGym.AI and Blue Owl,
+              before joining LivePerson full-time.
+            </p>
+            <div className="about-stats reveal" data-delay="3">
+              <div className="stat">
+                <span className="num">7+</span>
+                <span className="lbl">years shipping</span>
+              </div>
+              <div className="stat">
+                <span className="num">2</span>
+                <span className="lbl">languages — PL / EN</span>
+              </div>
+              <div className="stat">
+                <span className="num">BSc</span>
+                <span className="lbl">AI, Groningen</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* CAPABILITIES */}
+      <section className="section-pad alt" id="capabilities">
+        <div className="wrap">
+          <div className="sec-head reveal">
+            <span className="kicker">
+              <span className="idx">02</span> — Capabilities
+            </span>
+            <h2 className="section-title">What I do</h2>
+          </div>
+          <div className="cap-grid">
+            {capabilities.map((cap, i) => (
+              <article
+                className="cap-card card reveal"
+                key={cap.num}
+                data-delay={i > 0 ? String(i) : undefined}
+              >
+                <span className="cap-num">{cap.num}</span>
+                <h3>{cap.title}</h3>
+                <p>{cap.body}</p>
+                <div className="tag-row">
+                  {cap.tags.map((tag) => (
+                    <span className="tag" key={tag}>
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* SELECTED WORK */}
+      <section className="section-pad" id="work">
+        <div className="wrap">
+          <div className="sec-head reveal">
+            <span className="kicker">
+              <span className="idx">03</span> — Selected work
+            </span>
+            <h2 className="section-title">Things I've built</h2>
+          </div>
+          <div className="work-list">
+            {work.map((item) => (
+              <Link className="work-row reveal" to="/cv" key={item.idx}>
+                <span className="work-idx">{item.idx}</span>
+                <div className="work-main">
+                  <h3>{item.title}</h3>
+                  <p>{item.desc}</p>
+                </div>
+                <div className="work-tags">
+                  {item.tags.map((tag) => (
+                    <span className="tag" key={tag}>
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+                <span className="work-arrow">→</span>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ASSISTANT TEASER */}
+      <section className="section-pad alt" id="assistant-teaser">
+        <div className="wrap">
+          <div className="assistant-card card reveal">
+            <div className="assistant-copy">
+              <span className="kicker">
+                <span className="idx">04</span> — Live demo
+              </span>
+              <h2 className="section-title">Ask my AI assistant anything.</h2>
+              <p className="lead">
+                A small taste of what I build. Trained on my background, it
+                answers questions about my work — or passes a message straight to
+                me.
+              </p>
+              <Link className="btn btn-primary" data-magnetic to="/assistant">
+                Open the assistant <span className="arrow">→</span>
+              </Link>
+            </div>
+            <div className="assistant-preview" aria-hidden="true">
+              <div className="chat-bubble user">
+                What has Daniel shipped with LLMs?
+              </div>
+              <div className="chat-bubble bot">
+                <span className="bot-avatar">DA</span>
+                <span>
+                  Plenty — production agents at LivePerson, GPT learning
+                  pipelines at BrainGym.AI, and a sales agent for SteelProfil.
+                  Want specifics on any?
+                </span>
+              </div>
+              <div className="chat-typing">
+                <span />
+                <span />
+                <span />
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <PortfolioFooter variant="full" />
+    </>
+  );
+};
+
+export default HomePageLayout;

--- a/src/components/layouts/pages/general/MyCVPageLayout.tsx
+++ b/src/components/layouts/pages/general/MyCVPageLayout.tsx
@@ -1,9 +1,8 @@
 import React, { useEffect, useState } from "react";
-import PageLayout from "../PageLayout";
+import { Link } from "react-router-dom";
 import SkillSet from "../../../../data/SkillSet";
 import database, { timestampToString } from "../../../../data/database";
 import Experience from "../../../../data/experience";
-
 import EducationItem from "../../../../data/EducationItem";
 import { useAuth } from "../../../../contexts/AuthContext";
 import AddExperiencePopup from "../../../molecules/popups/experience/AddExperiencePopup";
@@ -20,37 +19,34 @@ import Button, {
   ButtonSize,
   ButtonType,
 } from "../../../atoms/buttons and links/Button";
-import {
-  CVContainer,
-  CVTitle,
-  CVMainContainer,
-  ContentColumn,
-  Section,
-  SectionTitle,
-  AboutText,
-  SkillSetContainer,
-  SkillSetTitle,
-  SkillsList,
-  SkillItem,
-  HobbiesContainer,
-  HobbyItem,
-  ExperienceSection,
-  ExperienceItem,
-  ExperienceTitle,
-  ExperienceDate,
-  ExperienceDescription,
-  EducationSection,
-  EducationItem as StyledEducationItem,
-  EducationTitle,
-  EducationPlace,
-  EducationYears,
-  ProfileColumn,
-  ProfileImage,
-  ProfileInfo,
-  ProfileName,
-  ProfileTitle,
-  ContactInfo,
-} from "./MyCVPageLayout.styled";
+import PortfolioFooter from "../../../molecules/general/PortfolioFooter";
+import useScrollReveal from "../../../../hooks/useScrollReveal";
+
+const MailIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7">
+    <rect x="3" y="5" width="18" height="14" rx="2" />
+    <path d="m3 7 9 6 9-6" />
+  </svg>
+);
+
+const PhoneIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7">
+    <path d="M22 16.9v3a2 2 0 0 1-2.2 2 19.8 19.8 0 0 1-8.6-3 19.5 19.5 0 0 1-6-6 19.8 19.8 0 0 1-3-8.6A2 2 0 0 1 4.1 2h3a2 2 0 0 1 2 1.7c.1 1 .4 1.9.7 2.8a2 2 0 0 1-.5 2.1L8.1 9.9a16 16 0 0 0 6 6l1.3-1.3a2 2 0 0 1 2.1-.4c.9.3 1.8.6 2.8.7a2 2 0 0 1 1.7 2z" />
+  </svg>
+);
+
+const PinIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7">
+    <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0z" />
+    <circle cx="12" cy="10" r="3" />
+  </svg>
+);
+
+const LinkedInIcon = () => (
+  <svg viewBox="0 0 24 24" fill="currentColor">
+    <path d="M4.98 3.5A2.5 2.5 0 1 1 5 8.5a2.5 2.5 0 0 1 0-5zM3 9h4v12H3zM10 9h3.8v1.7h.05c.53-1 1.83-2.05 3.77-2.05 4.03 0 4.78 2.65 4.78 6.1V21h-4v-5.3c0-1.27-.02-2.9-1.77-2.9s-2.04 1.38-2.04 2.8V21h-4z" />
+  </svg>
+);
 
 const MyCVPageLayout: React.FC = () => {
   const [skillSets, setSkillSets] = useState<SkillSet[]>([]);
@@ -97,11 +93,8 @@ const MyCVPageLayout: React.FC = () => {
     useState<EducationItem | null>(null);
 
   // Skill set management functionality
-  const [
-    isAddSkillSetPopupShown,
-    showAddSkillSetPopup,
-    hideAddSkillSetPopup,
-  ] = usePopup();
+  const [isAddSkillSetPopupShown, showAddSkillSetPopup, hideAddSkillSetPopup] =
+    usePopup();
   const [
     isEditSkillSetPopupShown,
     showEditSkillSetPopup,
@@ -112,8 +105,11 @@ const MyCVPageLayout: React.FC = () => {
     showRemoveSkillSetPopup,
     hideRemoveSkillSetPopup,
   ] = usePopup();
-  const [selectedSkillSet, setSelectedSkillSet] =
-    useState<SkillSet | null>(null);
+  const [selectedSkillSet, setSelectedSkillSet] = useState<SkillSet | null>(
+    null
+  );
+
+  useScrollReveal([experiences.length, education.length, skillSets.length]);
 
   const onAddButtonClick = () => {
     window.document.body.style.overflow = "hidden";
@@ -168,7 +164,6 @@ const MyCVPageLayout: React.FC = () => {
   const onAddExperienceClose = (addedExperience?: Experience) => {
     hideAddExperiencePopup();
     if (addedExperience) {
-      // Add new experience and sort by importance in descending order
       const updatedExperiences = [...experiences, addedExperience].sort(
         (a, b) => b.importance - a.importance
       );
@@ -180,7 +175,6 @@ const MyCVPageLayout: React.FC = () => {
   const onEditExperienceClose = (updatedExperience?: Experience) => {
     hideEditExperiencePopup();
     if (updatedExperience) {
-      // Update the experience and sort by importance in descending order
       const updatedExperiences = experiences
         .map((exp) =>
           exp.id === updatedExperience.id ? updatedExperience : exp
@@ -191,15 +185,11 @@ const MyCVPageLayout: React.FC = () => {
     window.document.body.style.overflow = "unset";
   };
 
-  const onRemoveExperiencesClose = (
-    removedExperiences?: Experience[]
-  ): void => {
+  const onRemoveExperiencesClose = (removedExperiences?: Experience[]): void => {
     hideRemoveExperiencesPopup();
     if (removedExperiences) {
       const removedIds = removedExperiences.map((exp) => exp.id);
-      setExperiences(
-        experiences.filter((exp) => !removedIds.includes(exp.id))
-      );
+      setExperiences(experiences.filter((exp) => !removedIds.includes(exp.id)));
     }
     window.document.body.style.overflow = "unset";
   };
@@ -222,9 +212,7 @@ const MyCVPageLayout: React.FC = () => {
     hideEditEducationPopup();
     if (updatedEducation) {
       const updatedEducationList = education
-        .map((edu) =>
-          edu.id === updatedEducation.id ? updatedEducation : edu
-        )
+        .map((edu) => (edu.id === updatedEducation.id ? updatedEducation : edu))
         .sort((a, b) => {
           if (b.endYear === "ongoing") return 1;
           if (a.endYear === "ongoing") return -1;
@@ -267,31 +255,41 @@ const MyCVPageLayout: React.FC = () => {
   const onRemoveSkillSetClose = (deletedIds?: string[]) => {
     hideRemoveSkillSetPopup();
     if (deletedIds) {
-      setSkillSets(skillSets.filter((skillSet) => !deletedIds.includes(skillSet.id)));
+      setSkillSets(
+        skillSets.filter((skillSet) => !deletedIds.includes(skillSet.id))
+      );
     }
     window.document.body.style.overflow = "unset";
   };
 
   useEffect(() => {
-    database.skillSets.getAll().then((skillSets) => {
-      setSkillSets(skillSets);
-    });
+    document.title = "Daniel Aboo — Curriculum Vitae";
 
+    database.skillSets.getAll().then((sets) => setSkillSets(sets));
     database.experiences
       .getAll({ field: "importance", direction: "desc" })
-      .then((experiences) => {
-        setExperiences(experiences);
-      });
-
+      .then((items) => setExperiences(items));
     database.education
       .getAll({ field: "endYear", direction: "desc" })
-      .then((items) => {
-        setEducation(items);
-      });
+      .then((items) => setEducation(items));
   }, []);
+
+  const formatExperienceDate = (experience: Experience) => {
+    const start = experience.startingDate
+      ? timestampToString(experience.startingDate, false, false)
+      : "";
+    if (experience.endDate === "ongoing") {
+      return `${start ? start + " " : ""}— Present`;
+    }
+    const end = experience.endDate
+      ? timestampToString(experience.endDate, false, false)
+      : "";
+    return [start, end].filter(Boolean).join(" — ");
+  };
 
   return (
     <>
+      {/* Experience / Education / Skill-set management popups (owner only) */}
       <AddExperiencePopup
         isPopupShown={isAddExperiencePopupShown}
         onClose={onAddExperienceClose}
@@ -334,137 +332,92 @@ const MyCVPageLayout: React.FC = () => {
         skillSets={skillSets}
         onClose={onRemoveSkillSetClose}
       />
-      <PageLayout title="CV">
-        <CVContainer>
-          {/* Experience Management Popups */}
-          {/* Education Management Popups */}
 
-          <CVTitle>Curriculum Vitae</CVTitle>
-          <CVMainContainer>
-            <ContentColumn>
-              <Section>
-                <SectionTitle>About Me</SectionTitle>
-                <AboutText>
-                  I have been always, looking into the future, wanting to create
-                  new solutions using technology to change how we live our
-                  everyday lives. My mission is to innovate, while also make my
-                  work to be understood by others and be able to work together
-                  with people. Creativity, my pursuit after my goals and my
-                  determination are my main attributes. I always try my best to
-                  understand the needs of people I work with, and find a way for
-                  all parties to be happy.
-                </AboutText>
-              </Section>
+      {/* HEADER */}
+      <section className="wrap cv-header">
+        <span className="kicker reveal in">
+          <span className="idx">CV</span> — Curriculum Vitae
+        </span>
+        <h1 className="cv-name reveal in" data-delay="1">
+          Daniel Richard Aboo
+        </h1>
+        <p className="cv-role reveal in" data-delay="2">
+          Full-Stack Developer &amp; Prompt Engineer · Building production AI.
+        </p>
+        <div className="cv-actions reveal in" data-delay="3">
+          <button className="btn btn-primary" onClick={() => window.print()}>
+            Download / Print PDF <span className="arrow">↓</span>
+          </button>
+          <Link className="btn btn-ghost" to="/contact">
+            Contact me
+          </Link>
+        </div>
+      </section>
 
-              <Section>
-                <SectionTitle>
-                  Skills
-                  {auth.isOwner && (
-                    <div style={{ display: 'flex', gap: '10px', marginTop: '10px' }}>
-                      <Button
-                        label="Add"
-                        action={onAddSkillSetClick}
-                        size={ButtonSize.small}
-                        type={ButtonType.constructive}
-                      />
-                      <Button
-                        label="Remove"
-                        action={onRemoveSkillSetClick}
-                        size={ButtonSize.small}
-                        type={ButtonType.destructive}
-                      />
-                    </div>
-                  )}
-                </SectionTitle>
-                {skillSets.map((skillSet) => {
-                  return (
-                    <SkillSetContainer key={skillSet.name}>
-                      <SkillSetTitle>
-                        {skillSet.name}
-                        {auth.isOwner && (
-                          <span style={{ marginLeft: '10px' }}>
-                            <Button
-                              label="Edit"
-                              action={() => onEditSkillSetClick(skillSet)}
-                              size={ButtonSize.small}
-                              type={ButtonType.primary}
-                            />
-                          </span>
-                        )}
-                      </SkillSetTitle>
-                      <SkillsList>
-                        {skillSet.skills.map((skill) => {
-                          return (
-                            <SkillItem key={skill}>
-                              <p>{skill}</p>
-                            </SkillItem>
-                          );
-                        })}
-                      </SkillsList>
-                    </SkillSetContainer>
-                  );
-                })}
-              </Section>
+      <div className="wrap">
+        <div className="divider" />
+      </div>
 
-              <Section>
-                <SectionTitle className="with-top-padding">Hobbies</SectionTitle>
-                <HobbiesContainer>
-                  <HobbyItem>Programming</HobbyItem>
-                  <HobbyItem>Piano</HobbyItem>
-                  <HobbyItem>Traveling</HobbyItem>
-                  <HobbyItem>Photography</HobbyItem>
-                </HobbiesContainer>
-              </Section>
+      {/* LAYOUT */}
+      <div className="wrap" style={{ paddingTop: "clamp(2.5rem,5vw,4rem)" }}>
+        <div className="cv-layout">
+          {/* MAIN */}
+          <main className="cv-main">
+            <section className="cv-block reveal">
+              <div className="cv-block-title">
+                <h2>Profile</h2>
+              </div>
+              <p className="cv-summary">
+                I've always looked to the future — building solutions with
+                technology that change how we live day to day. My mission is to
+                innovate while keeping the work understandable and
+                collaborative. Creativity, drive and determination define how I
+                work; I listen carefully to the people I build with and find the
+                path where everyone wins.
+              </p>
+            </section>
 
-              <ExperienceSection>
-                <SectionTitle className="with-top-padding">
-                  Experience
-                </SectionTitle>
-                {auth.isOwner && (
-                  <div className="experience-admin-controls">
-                    <Button
-                      size={ButtonSize.small}
-                      action={onAddButtonClick}
-                      label="Add Experience"
-                      type={ButtonType.constructive}
-                    />
-                    <Button
-                      size={ButtonSize.small}
-                      label="Remove Experiences"
-                      action={onRemoveButtonClick}
-                      type={ButtonType.destructive}
-                    />
-                  </div>
-                )}
+            <section className="cv-block reveal">
+              <div className="cv-block-title">
+                <h2>Experience</h2>
+                <span className="count">
+                  {String(experiences.length).padStart(2, "0")}
+                </span>
+              </div>
+
+              {auth.isOwner && (
+                <div className="tag-row" style={{ marginBottom: "1.6rem" }}>
+                  <Button
+                    size={ButtonSize.small}
+                    action={onAddButtonClick}
+                    label="Add Experience"
+                    type={ButtonType.constructive}
+                  />
+                  <Button
+                    size={ButtonSize.small}
+                    label="Remove Experiences"
+                    action={onRemoveButtonClick}
+                    type={ButtonType.destructive}
+                  />
+                </div>
+              )}
+
+              <div className="timeline">
                 {experiences.map((experience) => {
+                  const isCurrent = experience.endDate === "ongoing";
                   return (
-                    <ExperienceItem key={experience.title}>
-                      <div className="experience-content">
-                        <ExperienceTitle>{experience.title}</ExperienceTitle>
-                        <ExperienceDate>
-                          {experience.endDate === "ongoing" && "Started in "}
-                          {experience?.startingDate &&
-                            timestampToString(
-                              experience.startingDate,
-                              false,
-                              false
-                            )}
-                          {experience.endDate &&
-                            (experience.endDate === "ongoing"
-                              ? "(ongoing)"
-                              : "- " +
-                                timestampToString(
-                                  experience.endDate,
-                                  false,
-                                  false
-                                ))}
-                        </ExperienceDate>
-                        <ExperienceDescription>
-                          {experience.description}
-                        </ExperienceDescription>
+                    <div
+                      className={`tl-item${isCurrent ? " current" : ""}`}
+                      key={experience.id ?? experience.title}
+                    >
+                      <div className="tl-meta">
+                        {isCurrent && <span className="now">● Now</span>}
+                        {formatExperienceDate(experience)}
                       </div>
+                      <h3 className="tl-role">{experience.title}</h3>
+                      <p className="tl-desc">{experience.description}</p>
                       {auth.isOwner && (
-                        <div className="experience-edit-button">
+                        <div className="tl-tags">
                           <Button
                             size={ButtonSize.small}
                             action={() => onEditButtonClick(experience)}
@@ -473,71 +426,171 @@ const MyCVPageLayout: React.FC = () => {
                           />
                         </div>
                       )}
-                    </ExperienceItem>
+                    </div>
                   );
                 })}
-              </ExperienceSection>
+              </div>
+            </section>
 
-              <EducationSection>
-                <SectionTitle className="with-top-padding">
-                  Education
+            <section className="cv-block reveal">
+              <div className="cv-block-title">
+                <h2>Education</h2>
+                {auth.isOwner && (
+                  <div className="tag-row">
+                    <Button
+                      label="Add"
+                      action={onAddEducationClick}
+                      size={ButtonSize.small}
+                      type={ButtonType.constructive}
+                    />
+                    <Button
+                      label="Remove"
+                      action={onRemoveEducationClick}
+                      size={ButtonSize.small}
+                      type={ButtonType.destructive}
+                    />
+                  </div>
+                )}
+              </div>
+              {education.map((item) => (
+                <div className="edu-item" key={item.id ?? item.qualification}>
+                  <div className="edu-q">{item.qualification}</div>
+                  <div className="edu-place">{item.place}</div>
+                  <div className="edu-years">
+                    {item.startYear} — {item.endYear}
+                  </div>
                   {auth.isOwner && (
-                    <div style={{ display: 'flex', gap: '10px', marginTop: '10px' }}>
+                    <div style={{ marginTop: "0.7rem" }}>
                       <Button
-                        label="Add"
-                        action={onAddEducationClick}
+                        label="Edit"
+                        action={() => onEditEducationClick(item)}
                         size={ButtonSize.small}
-                        type={ButtonType.constructive}
-                      />
-                      <Button
-                        label="Remove"
-                        action={onRemoveEducationClick}
-                        size={ButtonSize.small}
-                        type={ButtonType.destructive}
+                        type={ButtonType.primary}
                       />
                     </div>
                   )}
-                </SectionTitle>
-                {education.map((item) => {
-                  return (
-                    <StyledEducationItem key={item.qualification}>
-                      <EducationTitle>{item.qualification}</EducationTitle>
-                      <EducationPlace>{item.place}</EducationPlace>
-                      <EducationYears>
-                        {item.startYear} - {item.endYear}
-                      </EducationYears>
-                      {auth.isOwner && (
-                        <div style={{ marginTop: '10px' }}>
-                          <Button
-                            label="Edit"
-                            action={() => onEditEducationClick(item)}
-                            size={ButtonSize.small}
-                            type={ButtonType.primary}
-                          />
-                        </div>
-                      )}
-                    </StyledEducationItem>
-                  );
-                })}
-              </EducationSection>
-            </ContentColumn>
+                </div>
+              ))}
+            </section>
+          </main>
 
-            <ProfileColumn>
-              <ProfileImage src="/images/me.jpg" alt="Daniel Richard Aboo" />
-              <ProfileInfo>
-                <ProfileName>Daniel Richard Aboo</ProfileName>
-                <ProfileTitle>Full-stack Developer, Prompt Engineer</ProfileTitle>
-                <ContactInfo>
-                  Mobile: <a href="tel:+48601951169">+48 601 951 169</a>
-                </ContactInfo>
-                <ContactInfo className="email-only">
-                  Email: <a href="mailto:me@aboodaniel.pl">me@aboodaniel.pl</a>
-                </ContactInfo>
-              </ProfileInfo>
-            </ProfileColumn>
-          </CVMainContainer>
-        </CVContainer>
-      </PageLayout>
+          {/* SIDEBAR */}
+          <aside className="cv-side reveal" data-delay="1">
+            <div className="side-card side-photo card">
+              <img src="/images/me.jpg" alt="Daniel Aboo" />
+            </div>
+
+            <div className="side-card card">
+              <p className="side-head">Contact</p>
+              <div className="side-contact">
+                <a href="mailto:me@aboodaniel.pl">
+                  <span className="ico">
+                    <MailIcon />
+                  </span>
+                  me@aboodaniel.pl
+                </a>
+                <a href="tel:+48601951169">
+                  <span className="ico">
+                    <PhoneIcon />
+                  </span>
+                  +48 601 951 169
+                </a>
+                <span>
+                  <span className="ico">
+                    <PinIcon />
+                  </span>
+                  Poland
+                </span>
+                <a
+                  href="https://www.linkedin.com/in/danielaboo"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <span className="ico">
+                    <LinkedInIcon />
+                  </span>
+                  LinkedIn
+                </a>
+              </div>
+            </div>
+
+            <div className="side-card card">
+              <p className="side-head">Skills</p>
+              {auth.isOwner && (
+                <div className="tag-row" style={{ marginBottom: "1rem" }}>
+                  <Button
+                    label="Add"
+                    action={onAddSkillSetClick}
+                    size={ButtonSize.small}
+                    type={ButtonType.constructive}
+                  />
+                  <Button
+                    label="Remove"
+                    action={onRemoveSkillSetClick}
+                    size={ButtonSize.small}
+                    type={ButtonType.destructive}
+                  />
+                </div>
+              )}
+              {skillSets.map((skillSet) => (
+                <div className="skill-group" key={skillSet.name}>
+                  <h4>
+                    {skillSet.name}
+                    {auth.isOwner && (
+                      <span style={{ marginLeft: "10px" }}>
+                        <Button
+                          label="Edit"
+                          action={() => onEditSkillSetClick(skillSet)}
+                          size={ButtonSize.small}
+                          type={ButtonType.primary}
+                        />
+                      </span>
+                    )}
+                  </h4>
+                  <div className="hobby-row">
+                    {skillSet.skills.map((skill) => (
+                      <span className="tag" key={skill}>
+                        {skill}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div className="side-card card">
+              <p className="side-head">Languages</p>
+              <div className="lang-row">
+                <span>Polish</span>
+                <span className="lvl">Native</span>
+              </div>
+              <div className="lang-bar">
+                <span style={{ width: "100%" }} />
+              </div>
+              <div style={{ height: "0.9rem" }} />
+              <div className="lang-row">
+                <span>English</span>
+                <span className="lvl">Fluent · C1</span>
+              </div>
+              <div className="lang-bar">
+                <span style={{ width: "92%" }} />
+              </div>
+            </div>
+
+            <div className="side-card card">
+              <p className="side-head">Beyond Code</p>
+              <div className="hobby-row">
+                <span className="tag">Programming</span>
+                <span className="tag">Piano</span>
+                <span className="tag">Traveling</span>
+                <span className="tag">Photography</span>
+              </div>
+            </div>
+          </aside>
+        </div>
+      </div>
+
+      <PortfolioFooter variant="full" ctaLine="Like what you see? Let's build." />
     </>
   );
 };

--- a/src/components/molecules/general/HeroCanvas.tsx
+++ b/src/components/molecules/general/HeroCanvas.tsx
@@ -1,0 +1,132 @@
+import React, { useEffect, useRef } from "react";
+
+/**
+ * Hero atmosphere — interactive dot grid with accent glow.
+ * Ported from the design prototype's hero.js. Lightweight canvas;
+ * respects reduced-motion.
+ */
+const HeroCanvas: React.FC = () => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    const reduce = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+    let w = 0;
+    let h = 0;
+    let dpr = 1;
+    let dots: Array<{ x: number; y: number; ph: number }> = [];
+    let rafId = 0;
+    let resizeTimer: number | undefined;
+    const GAP = 38;
+    const mouse = { x: -9999, y: -9999, has: false };
+
+    const accent = () =>
+      getComputedStyle(document.documentElement)
+        .getPropertyValue("--accent")
+        .trim() || "oklch(0.6 0.2 256)";
+    const baseDot = () =>
+      getComputedStyle(document.documentElement)
+        .getPropertyValue("--border-2")
+        .trim() || "#888";
+
+    const resize = () => {
+      dpr = Math.min(window.devicePixelRatio || 1, 2);
+      const rect = canvas.getBoundingClientRect();
+      w = rect.width;
+      h = rect.height;
+      canvas.width = w * dpr;
+      canvas.height = h * dpr;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      dots = [];
+      const cols = Math.ceil(w / GAP) + 1;
+      const rows = Math.ceil(h / GAP) + 1;
+      for (let i = 0; i < cols; i++) {
+        for (let j = 0; j < rows; j++) {
+          dots.push({ x: i * GAP, y: j * GAP, ph: Math.random() * Math.PI * 2 });
+        }
+      }
+    };
+
+    let t = 0;
+    const frame = () => {
+      t += 0.012;
+      ctx.clearRect(0, 0, w, h);
+      const ac = accent();
+      const base = baseDot();
+      const R = 150;
+      for (let k = 0; k < dots.length; k++) {
+        const d = dots[k];
+        let r = 0.9 + Math.sin(t + d.ph) * 0.35;
+        let near = 0;
+        if (mouse.has) {
+          const dx = d.x - mouse.x;
+          const dy = d.y - mouse.y;
+          const dist = Math.sqrt(dx * dx + dy * dy);
+          if (dist < R) near = 1 - dist / R;
+        }
+        if (near > 0.02) {
+          ctx.fillStyle = ac;
+          ctx.globalAlpha = 0.25 + near * 0.75;
+          r = 0.9 + near * 2.6;
+        } else {
+          ctx.fillStyle = base;
+          ctx.globalAlpha = 0.4;
+        }
+        ctx.beginPath();
+        ctx.arc(d.x, d.y, r, 0, Math.PI * 2);
+        ctx.fill();
+      }
+      ctx.globalAlpha = 1;
+      if (!reduce) rafId = requestAnimationFrame(frame);
+    };
+
+    const host = canvas.parentElement;
+    const onMove = (e: MouseEvent) => {
+      const rect = canvas.getBoundingClientRect();
+      mouse.x = e.clientX - rect.left;
+      mouse.y = e.clientY - rect.top;
+      mouse.has = true;
+    };
+    const onLeave = () => {
+      mouse.has = false;
+      mouse.x = -9999;
+      mouse.y = -9999;
+    };
+    const onResize = () => {
+      window.clearTimeout(resizeTimer);
+      resizeTimer = window.setTimeout(resize, 150);
+    };
+
+    if (host) {
+      host.addEventListener("mousemove", onMove);
+      host.addEventListener("mouseleave", onLeave);
+    }
+    window.addEventListener("resize", onResize);
+
+    resize();
+    if (reduce) frame();
+    else rafId = requestAnimationFrame(frame);
+
+    return () => {
+      if (rafId) cancelAnimationFrame(rafId);
+      window.clearTimeout(resizeTimer);
+      window.removeEventListener("resize", onResize);
+      if (host) {
+        host.removeEventListener("mousemove", onMove);
+        host.removeEventListener("mouseleave", onLeave);
+      }
+    };
+  }, []);
+
+  return (
+    <div className="hero-canvas-host">
+      <canvas id="hero-canvas" ref={canvasRef} />
+    </div>
+  );
+};
+
+export default HeroCanvas;

--- a/src/components/molecules/general/Navbar.tsx
+++ b/src/components/molecules/general/Navbar.tsx
@@ -1,0 +1,116 @@
+import React, { useEffect, useState } from "react";
+import { Link, useLocation } from "react-router-dom";
+import { useThemeMode } from "../../../contexts/ThemeModeContext";
+
+const SunIcon = () => (
+  <svg
+    className="sun"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.8"
+    strokeLinecap="round"
+  >
+    <circle cx="12" cy="12" r="4.2" />
+    <path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4" />
+  </svg>
+);
+
+const MoonIcon = () => (
+  <svg className="moon" viewBox="0 0 24 24" fill="currentColor">
+    <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z" />
+  </svg>
+);
+
+const links: Array<{ to: string; label: string }> = [
+  { to: "/", label: "Home" },
+  { to: "/cv", label: "CV" },
+  { to: "/assistant", label: "Assistant" },
+  { to: "/contact", label: "Contact" },
+];
+
+const Navbar: React.FC = () => {
+  const location = useLocation();
+  const { toggle } = useThemeMode();
+  const [scrolled, setScrolled] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 8);
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  // close mobile menu on route change
+  useEffect(() => {
+    setMenuOpen(false);
+  }, [location.pathname]);
+
+  const isActive = (to: string) =>
+    to === "/" ? location.pathname === "/" : location.pathname.startsWith(to);
+
+  return (
+    <header className={`nav${scrolled ? " scrolled" : ""}`}>
+      <div className="nav-inner">
+        <Link className="brand" to="/" aria-label="Daniel Aboo — home">
+          <span className="mark">DA</span>
+          <span>
+            Daniel Aboo<small>PROMPT ENGINEER</small>
+          </span>
+        </Link>
+        <nav
+          className={`nav-links${menuOpen ? " open" : ""}`}
+          aria-label="Primary"
+        >
+          {links.map((link) => (
+            <Link
+              key={link.to}
+              className={`nav-link${isActive(link.to) ? " active" : ""}`}
+              to={link.to}
+            >
+              {link.label}
+            </Link>
+          ))}
+        </nav>
+        <div className="nav-right">
+          <button
+            className="theme-toggle"
+            onClick={toggle}
+            aria-label="Toggle dark mode"
+            type="button"
+          >
+            <SunIcon />
+            <MoonIcon />
+          </button>
+          <Link
+            className="btn btn-primary"
+            to="/contact"
+            style={{ padding: "0.6rem 1.1rem" }}
+          >
+            Work with me
+          </Link>
+          <button
+            className="menu-btn"
+            onClick={() => setMenuOpen((o) => !o)}
+            aria-label="Menu"
+            aria-expanded={menuOpen}
+            type="button"
+          >
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.8"
+              strokeLinecap="round"
+            >
+              <path d="M3 6h18M3 12h18M3 18h18" />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </header>
+  );
+};
+
+export default Navbar;

--- a/src/components/molecules/general/Navbar.tsx
+++ b/src/components/molecules/general/Navbar.tsx
@@ -51,50 +51,79 @@ const Navbar: React.FC = () => {
     to === "/" ? location.pathname === "/" : location.pathname.startsWith(to);
 
   return (
-    <header className={`nav${scrolled ? " scrolled" : ""}`}>
-      <div className="nav-inner">
-        <Link className="brand" to="/" aria-label="Daniel Aboo — home">
-          <span className="mark">DA</span>
-          <span>
-            Daniel Aboo<small>PROMPT ENGINEER</small>
-          </span>
-        </Link>
-        <nav
-          className={`nav-links${menuOpen ? " open" : ""}`}
-          aria-label="Primary"
-        >
-          {links.map((link) => (
-            <Link
-              key={link.to}
-              className={`nav-link${isActive(link.to) ? " active" : ""}`}
-              to={link.to}
-            >
-              {link.label}
-            </Link>
-          ))}
-        </nav>
-        <div className="nav-right">
-          <button
-            className="theme-toggle"
-            onClick={toggle}
-            aria-label="Toggle dark mode"
-            type="button"
-          >
-            <SunIcon />
-            <MoonIcon />
-          </button>
-          <Link
-            className="btn btn-primary"
-            to="/contact"
-            style={{ padding: "0.6rem 1.1rem" }}
-          >
-            Work with me
+    <>
+      <header className={`nav${scrolled ? " scrolled" : ""}`}>
+        <div className="nav-inner">
+          <Link className="brand" to="/" aria-label="Daniel Aboo — home">
+            <span className="mark">DA</span>
+            <span>
+              Daniel Aboo<small>PROMPT ENGINEER</small>
+            </span>
           </Link>
+          <nav className="nav-links" aria-label="Primary">
+            {links.map((link) => (
+              <Link
+                key={link.to}
+                className={`nav-link${isActive(link.to) ? " active" : ""}`}
+                to={link.to}
+              >
+                {link.label}
+              </Link>
+            ))}
+          </nav>
+          <div className="nav-right">
+            <button
+              className="theme-toggle"
+              onClick={toggle}
+              aria-label="Toggle dark mode"
+              type="button"
+            >
+              <SunIcon />
+              <MoonIcon />
+            </button>
+            <Link
+              className="btn btn-primary"
+              to="/contact"
+              style={{ padding: "0.6rem 1.1rem" }}
+            >
+              Work with me
+            </Link>
+            <button
+              className="menu-btn"
+              onClick={() => setMenuOpen((o) => !o)}
+              aria-label="Menu"
+              aria-expanded={menuOpen}
+              type="button"
+            >
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                strokeLinecap="round"
+              >
+                <path d="M3 6h18M3 12h18M3 18h18" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </header>
+
+      {/* Mobile slide-out drawer — rendered outside the backdrop-filtered
+          <header> so its `position: fixed` resolves against the viewport. */}
+      <div
+        className={`nav-drawer${menuOpen ? " open" : ""}`}
+        aria-hidden={!menuOpen}
+      >
+        <div
+          className="nav-drawer-backdrop"
+          onClick={() => setMenuOpen(false)}
+        />
+        <nav className="nav-drawer-panel" aria-label="Mobile">
           <button
-            className="menu-btn"
-            onClick={() => setMenuOpen((o) => !o)}
-            aria-label="Menu"
-            aria-expanded={menuOpen}
+            className="nav-drawer-close"
+            onClick={() => setMenuOpen(false)}
+            aria-label="Close menu"
             type="button"
           >
             <svg
@@ -104,12 +133,22 @@ const Navbar: React.FC = () => {
               strokeWidth="1.8"
               strokeLinecap="round"
             >
-              <path d="M3 6h18M3 12h18M3 18h18" />
+              <path d="M6 6l12 12M18 6 6 18" />
             </svg>
           </button>
-        </div>
+          {links.map((link) => (
+            <Link
+              key={link.to}
+              className={`nav-link${isActive(link.to) ? " active" : ""}`}
+              to={link.to}
+              onClick={() => setMenuOpen(false)}
+            >
+              {link.label}
+            </Link>
+          ))}
+        </nav>
       </div>
-    </header>
+    </>
   );
 };
 

--- a/src/components/molecules/general/PortfolioFooter.tsx
+++ b/src/components/molecules/general/PortfolioFooter.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { useAuth } from "../../../contexts/AuthContext";
+
+interface PortfolioFooterProps {
+  /** "full" = CTA + navigation columns (home / cv). "minimal" = bottom meta only (contact). */
+  variant?: "full" | "minimal";
+  /** Copy shown in the CTA column of the full footer. */
+  ctaLine?: string;
+}
+
+const PortfolioFooter: React.FC<PortfolioFooterProps> = ({
+  variant = "full",
+  ctaLine = "Have an idea worth building?",
+}) => {
+  const auth = useAuth();
+
+  if (variant === "minimal") {
+    return (
+      <footer className="footer">
+        <div className="wrap">
+          <div
+            className="footer-bottom"
+            style={{ borderTop: "none", marginTop: 0, paddingTop: 0 }}
+          >
+            <span className="footer-meta">© 2026 Daniel Aboo · aboodaniel.pl</span>
+            <span className="footer-meta">Designed &amp; built with intent.</span>
+          </div>
+        </div>
+      </footer>
+    );
+  }
+
+  return (
+    <footer className="footer">
+      <div className="wrap">
+        <div className="footer-grid">
+          <div className="reveal">
+            <span className="kicker">
+              <span className="idx">05</span> — Let's talk
+            </span>
+            <p className="cta-line">{ctaLine}</p>
+            <Link
+              className="btn btn-primary"
+              data-magnetic
+              to="/contact"
+              style={{ marginTop: "1.4rem" }}
+            >
+              Get in touch <span className="arrow">→</span>
+            </Link>
+          </div>
+          <div className="reveal" data-delay="1">
+            <p className="footer-head">Navigate</p>
+            <div className="footer-links">
+              <Link to="/">Home</Link>
+              <Link to="/cv">Curriculum Vitae</Link>
+              <Link to="/assistant">AI Assistant</Link>
+              <Link to="/contact">Contact</Link>
+              {auth.isDeveloper && (
+                <Link to="/developerTools">Developer Tools</Link>
+              )}
+              {auth.isOwner && <Link to="/messages">Messages</Link>}
+            </div>
+          </div>
+          <div className="reveal" data-delay="2">
+            <p className="footer-head">Elsewhere</p>
+            <div className="footer-links">
+              <a href="mailto:me@aboodaniel.pl">me@aboodaniel.pl</a>
+              <a href="tel:+48601951169">+48 601 951 169</a>
+              <a
+                href="https://www.linkedin.com/in/danielaboo"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                LinkedIn ↗
+              </a>
+              {!auth.isLoggedIn ? (
+                <Link to="/login">Login</Link>
+              ) : (
+                <button type="button" onClick={auth.logout}>
+                  Logout
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+        <div className="footer-bottom">
+          <span className="footer-meta">© 2026 Daniel Aboo · aboodaniel.pl</span>
+          <span className="footer-meta">Designed &amp; built with intent.</span>
+        </div>
+      </div>
+    </footer>
+  );
+};
+
+export default PortfolioFooter;

--- a/src/contexts/ThemeModeContext.tsx
+++ b/src/contexts/ThemeModeContext.tsx
@@ -1,0 +1,51 @@
+import React, { useCallback, useContext, useEffect, useState } from "react";
+
+type Mode = "light" | "dark";
+
+const STORAGE_KEY = "da-theme";
+
+interface ThemeModeContextValue {
+  mode: Mode;
+  toggle: () => void;
+}
+
+const ThemeModeContext = React.createContext<ThemeModeContextValue>({
+  mode: "light",
+  toggle: () => {},
+});
+
+const getInitialMode = (): Mode => {
+  if (typeof window === "undefined") return "light";
+  const saved = window.localStorage.getItem(STORAGE_KEY);
+  if (saved === "light" || saved === "dark") return saved;
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+};
+
+const applyMode = (mode: Mode) => {
+  document.documentElement.setAttribute("data-theme", mode);
+};
+
+const ThemeModeProvider: React.FC = ({ children }) => {
+  const [mode, setMode] = useState<Mode>(getInitialMode);
+
+  useEffect(() => {
+    applyMode(mode);
+    window.localStorage.setItem(STORAGE_KEY, mode);
+  }, [mode]);
+
+  const toggle = useCallback(() => {
+    setMode((prev) => (prev === "dark" ? "light" : "dark"));
+  }, []);
+
+  return (
+    <ThemeModeContext.Provider value={{ mode, toggle }}>
+      {children}
+    </ThemeModeContext.Provider>
+  );
+};
+
+export const useThemeMode = () => useContext(ThemeModeContext);
+
+export default ThemeModeProvider;

--- a/src/hooks/useScrollReveal.tsx
+++ b/src/hooks/useScrollReveal.tsx
@@ -1,0 +1,90 @@
+import { useEffect } from "react";
+
+/**
+ * Scroll reveals + magnetic buttons, ported from the design prototype's app.js.
+ *
+ * Geometry-based (rather than IntersectionObserver) so it is robust across
+ * environments. Above-the-fold `.reveal` elements are shown instantly on the
+ * first pass; below-fold ones animate in as they enter the viewport.
+ *
+ * Call once per page after its content has mounted. `deps` lets the scan re-run
+ * when the rendered content changes.
+ */
+const useScrollReveal = (deps: ReadonlyArray<unknown> = []) => {
+  useEffect(() => {
+    let reveals = Array.prototype.slice.call(
+      document.querySelectorAll(".reveal")
+    ) as HTMLElement[];
+    let ticking = false;
+    let firstPass = true;
+
+    const checkReveals = () => {
+      ticking = false;
+      const vh = window.innerHeight || document.documentElement.clientHeight;
+      for (let i = reveals.length - 1; i >= 0; i--) {
+        const el = reveals[i];
+        const top = el.getBoundingClientRect().top;
+        if (firstPass && top < vh) {
+          el.style.transition = "none";
+          el.classList.add("in");
+          el.style.opacity = "1";
+          el.style.transform = "none";
+          reveals.splice(i, 1);
+        } else if (!firstPass && top < vh * 0.9) {
+          el.classList.add("in");
+          el.style.opacity = "1";
+          el.style.transform = "none";
+          reveals.splice(i, 1);
+        }
+      }
+      firstPass = false;
+    };
+
+    const onScrollResize = () => {
+      if (!ticking) {
+        ticking = true;
+        requestAnimationFrame(checkReveals);
+      }
+    };
+
+    let timer: number | undefined;
+    if (reveals.length) {
+      checkReveals();
+      timer = window.setTimeout(checkReveals, 500);
+      window.addEventListener("scroll", onScrollResize, { passive: true });
+      window.addEventListener("resize", onScrollResize, { passive: true });
+    }
+
+    // magnetic buttons (subtle) — skip on touch devices
+    const magnetCleanups: Array<() => void> = [];
+    if (!window.matchMedia("(pointer: coarse)").matches) {
+      document.querySelectorAll<HTMLElement>("[data-magnetic]").forEach((el) => {
+        const onMove = (e: MouseEvent) => {
+          const r = el.getBoundingClientRect();
+          const x = e.clientX - r.left - r.width / 2;
+          const y = e.clientY - r.top - r.height / 2;
+          el.style.transform = "translate(" + x * 0.18 + "px," + y * 0.22 + "px)";
+        };
+        const onLeave = () => {
+          el.style.transform = "";
+        };
+        el.addEventListener("mousemove", onMove);
+        el.addEventListener("mouseleave", onLeave);
+        magnetCleanups.push(() => {
+          el.removeEventListener("mousemove", onMove);
+          el.removeEventListener("mouseleave", onLeave);
+        });
+      });
+    }
+
+    return () => {
+      if (timer) window.clearTimeout(timer);
+      window.removeEventListener("scroll", onScrollResize);
+      window.removeEventListener("resize", onScrollResize);
+      magnetCleanups.forEach((fn) => fn());
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+};
+
+export default useScrollReveal;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,16 +8,19 @@ import { GlobalStyles } from "./styles/GlobalStyles";
 import "./index.css";
 import "./styles/accessibility.css";
 import { AccessibilityProvider } from "./contexts/AccessibilityContext";
+import ThemeModeProvider from "./contexts/ThemeModeContext";
 
 ReactDOM.render(
   <React.StrictMode>
     <ThemeProvider theme={theme}>
       <GlobalStyles />
-      <AccessibilityProvider>
-        <AuthContextProvider>
-          <App />
-        </AuthContextProvider>
-      </AccessibilityProvider>
+      <ThemeModeProvider>
+        <AccessibilityProvider>
+          <AuthContextProvider>
+            <App />
+          </AuthContextProvider>
+        </AccessibilityProvider>
+      </ThemeModeProvider>
     </ThemeProvider>
   </React.StrictMode>,
   document.getElementById("root")

--- a/src/styles/GlobalStyles.ts
+++ b/src/styles/GlobalStyles.ts
@@ -1,141 +1,637 @@
 import { createGlobalStyle } from 'styled-components';
-import { theme } from './theme';
 
+/* ============================================================
+   Daniel Aboo — Portfolio Design System
+   "Precision / AI" : clean monochrome base + electric accent.
+   Ported from the Claude Design handoff (HTML/CSS prototype)
+   into the React app as a global stylesheet. Light + dark via
+   the [data-theme] attribute on <html> (see ThemeModeContext).
+   ============================================================ */
 export const GlobalStyles = createGlobalStyle`
+  /* ---------- Tokens ---------- */
+  :root {
+    --font-sans: 'Geist', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    --font-mono: 'Geist Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+
+    /* Light theme (default) */
+    --bg:        oklch(0.985 0.002 250);
+    --bg-2:      oklch(0.965 0.003 250);
+    --surface:   oklch(1 0 0);
+    --surface-2: oklch(0.978 0.003 250);
+    --text:      oklch(0.20 0.012 264);
+    --text-2:    oklch(0.44 0.012 264);
+    --text-3:    oklch(0.60 0.010 264);
+    --border:    oklch(0.91 0.005 264);
+    --border-2:  oklch(0.86 0.006 264);
+    --accent:    oklch(0.58 0.20 256);
+    --accent-2:  oklch(0.52 0.21 256);
+    --accent-soft: oklch(0.58 0.20 256 / 0.10);
+    --accent-glow: oklch(0.58 0.20 256 / 0.22);
+    --shadow-sm: 0 1px 2px oklch(0.2 0.02 264 / 0.06), 0 1px 3px oklch(0.2 0.02 264 / 0.05);
+    --shadow-md: 0 4px 16px oklch(0.2 0.02 264 / 0.07), 0 1px 4px oklch(0.2 0.02 264 / 0.05);
+    --shadow-lg: 0 20px 50px oklch(0.2 0.02 264 / 0.12), 0 6px 18px oklch(0.2 0.02 264 / 0.07);
+
+    --maxw: 1180px;
+    --gutter: clamp(1.25rem, 4vw, 3rem);
+    --radius: 14px;
+    --radius-lg: 22px;
+    --ease: cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  [data-theme="dark"] {
+    --bg:        oklch(0.165 0.008 264);
+    --bg-2:      oklch(0.195 0.009 264);
+    --surface:   oklch(0.205 0.010 264);
+    --surface-2: oklch(0.235 0.011 264);
+    --text:      oklch(0.965 0.003 264);
+    --text-2:    oklch(0.74 0.010 264);
+    --text-3:    oklch(0.58 0.012 264);
+    --border:    oklch(0.30 0.012 264);
+    --border-2:  oklch(0.36 0.013 264);
+    --accent:    oklch(0.72 0.17 256);
+    --accent-2:  oklch(0.78 0.15 256);
+    --accent-soft: oklch(0.72 0.17 256 / 0.14);
+    --accent-glow: oklch(0.72 0.17 256 / 0.30);
+    --shadow-sm: 0 1px 2px oklch(0 0 0 / 0.4);
+    --shadow-md: 0 6px 22px oklch(0 0 0 / 0.45);
+    --shadow-lg: 0 28px 60px oklch(0 0 0 / 0.55);
+  }
+
+  * { box-sizing: border-box; }
+
+  html { scroll-behavior: smooth; }
+  @media (prefers-reduced-motion: reduce) {
+    html { scroll-behavior: auto; }
+    *, *::before, *::after { animation-duration: 0.001ms !important; transition-duration: 0.001ms !important; }
+  }
+
   body {
     margin: 0;
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-      'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-      sans-serif;
+    font-family: var(--font-sans);
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.6;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    background-color: ${theme.background.light};
-    color: ${theme.colors.gray[900]};
+    font-feature-settings: "cv01", "ss01";
+    transition: background 0.5s var(--ease), color 0.5s var(--ease);
+    overflow-x: hidden;
   }
 
-  @media (prefers-color-scheme: dark) {
-    body {
-      background-color: ${theme.background.dark};
-      color: ${theme.colors.white};
-    }
+  ::selection { background: var(--accent-glow); color: var(--text); }
+
+  a { color: inherit; text-decoration: none; }
+  img { display: block; max-width: 100%; }
+  button { font-family: inherit; }
+
+  /* ---------- Typography ---------- */
+  .kicker {
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    font-weight: 500;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-3);
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+  }
+  .kicker .idx { color: var(--accent); }
+  .kicker::before {
+    content: "";
+    width: 1.6rem; height: 1px;
+    background: var(--border-2);
+    display: inline-block;
   }
 
-  h1 {
-    font-size: ${theme.fontSizes['3xl']};
-    color: ${theme.colors.gray[500]};
-    width: 100%;
-    font-weight: ${theme.fontWeights.bold};
+  .display {
+    font-size: clamp(2.8rem, 8vw, 6.5rem);
+    font-weight: 600;
+    letter-spacing: -0.04em;
+    line-height: 0.96;
     margin: 0;
   }
-
-  @media (prefers-color-scheme: dark) {
-    h1 {
-      color: ${theme.colors.white};
-    }
-  }
-
-  h2 {
-    font-weight: ${theme.fontWeights.bold};
-    font-size: ${theme.fontSizes['2xl']};
+  h2.section-title, .section-title {
+    font-size: clamp(1.9rem, 4.2vw, 3.2rem);
+    letter-spacing: -0.03em;
+    font-weight: 600;
+    line-height: 1.05;
+    max-width: 16ch;
     margin: 0;
   }
-
-  @media (prefers-color-scheme: dark) {
-    h2 {
-      color: ${theme.colors.white};
-    }
-  }
-
-  h3 {
-    font-weight: ${theme.fontWeights.bold};
-    font-size: ${theme.fontSizes.xl};
+  .lead {
+    font-size: clamp(1.05rem, 1.6vw, 1.3rem);
+    color: var(--text-2);
+    line-height: 1.55;
+    font-weight: 400;
+    max-width: 60ch;
     margin: 0;
   }
+  .muted { color: var(--text-2); }
+  .accent-text { color: var(--accent); }
 
-  @media (prefers-color-scheme: dark) {
-    h3 {
-      color: ${theme.colors.white};
+  /* ---------- Layout ---------- */
+  .wrap { max-width: var(--maxw); margin-inline: auto; padding-inline: var(--gutter); }
+  section { position: relative; }
+  .section-pad { padding-block: clamp(4.5rem, 10vw, 9rem); }
+  .divider { height: 1px; background: var(--border); width: 100%; }
+
+  /* ---------- Buttons ---------- */
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    font-family: var(--font-sans);
+    font-size: 0.95rem;
+    font-weight: 500;
+    letter-spacing: -0.01em;
+    padding: 0.85rem 1.4rem;
+    border-radius: 999px;
+    border: 1px solid transparent;
+    cursor: pointer;
+    transition: transform 0.3s var(--ease), background 0.3s var(--ease),
+                border-color 0.3s var(--ease), box-shadow 0.3s var(--ease), color 0.3s var(--ease);
+    white-space: nowrap;
+  }
+  .btn:active { transform: scale(0.97); }
+  .btn-primary {
+    background: var(--accent);
+    color: oklch(0.99 0 0);
+    box-shadow: 0 6px 22px var(--accent-glow);
+  }
+  [data-theme="dark"] .btn-primary { color: oklch(0.15 0.01 264); }
+  .btn-primary:hover { background: var(--accent-2); transform: translateY(-2px); box-shadow: 0 10px 30px var(--accent-glow); }
+  .btn-ghost {
+    background: transparent;
+    color: var(--text);
+    border-color: var(--border-2);
+  }
+  .btn-ghost:hover { border-color: var(--text); transform: translateY(-2px); background: var(--surface-2); }
+  .btn .arrow { transition: transform 0.3s var(--ease); }
+  .btn:hover .arrow { transform: translateX(3px); }
+
+  /* ---------- Nav ---------- */
+  .nav {
+    position: sticky; top: 0; z-index: 100;
+    backdrop-filter: saturate(180%) blur(18px);
+    -webkit-backdrop-filter: saturate(180%) blur(18px);
+    background: color-mix(in oklch, var(--bg) 72%, transparent);
+    border-bottom: 1px solid transparent;
+    transition: border-color 0.4s var(--ease), background 0.4s var(--ease);
+  }
+  .nav.scrolled { border-bottom-color: var(--border); }
+  .nav-inner {
+    max-width: var(--maxw); margin-inline: auto;
+    padding: 0.9rem var(--gutter);
+    display: flex; align-items: center; justify-content: space-between;
+    gap: 1rem;
+  }
+  .brand { display: flex; align-items: center; gap: 0.7rem; font-weight: 600; letter-spacing: -0.02em; }
+  .brand .mark {
+    width: 34px; height: 34px; border-radius: 9px;
+    display: grid; place-items: center;
+    background: var(--text); color: var(--bg);
+    font-family: var(--font-mono); font-weight: 600; font-size: 0.95rem;
+    transition: background 0.4s var(--ease), color 0.4s var(--ease);
+  }
+  .brand small { font-family: var(--font-mono); font-size: 0.7rem; color: var(--text-3); display: block; line-height: 1; margin-top: 2px; letter-spacing: 0.02em; }
+
+  .nav-links { display: flex; align-items: center; gap: 0.35rem; }
+  .nav-link {
+    font-size: 0.92rem; font-weight: 450; color: var(--text-2);
+    padding: 0.5rem 0.9rem; border-radius: 999px;
+    position: relative; transition: color 0.25s var(--ease), background 0.25s var(--ease);
+    background: transparent; border: none; cursor: pointer;
+  }
+  .nav-link:hover { color: var(--text); }
+  .nav-link.active { color: var(--text); }
+  .nav-link.active::after {
+    content: ""; position: absolute; left: 50%; bottom: 0.1rem; transform: translateX(-50%);
+    width: 4px; height: 4px; border-radius: 50%; background: var(--accent);
+  }
+  .nav-right { display: flex; align-items: center; gap: 0.6rem; }
+
+  /* theme toggle */
+  .theme-toggle {
+    width: 38px; height: 38px; border-radius: 999px;
+    border: 1px solid var(--border-2); background: var(--surface);
+    display: grid; place-items: center; cursor: pointer; color: var(--text-2);
+    transition: color 0.25s var(--ease), border-color 0.25s var(--ease), transform 0.4s var(--ease), background 0.25s;
+  }
+  .theme-toggle:hover { color: var(--text); border-color: var(--text); transform: rotate(18deg); }
+  .theme-toggle svg { width: 17px; height: 17px; }
+  .theme-toggle .moon { display: none; }
+  [data-theme="dark"] .theme-toggle .sun { display: none; }
+  [data-theme="dark"] .theme-toggle .moon { display: block; }
+
+  .menu-btn { display: none; background: none; border: none; }
+
+  /* ---------- Cards / surfaces ---------- */
+  .card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    transition: border-color 0.35s var(--ease), transform 0.35s var(--ease), box-shadow 0.35s var(--ease), background 0.35s;
+  }
+  .card:hover { border-color: var(--border-2); }
+
+  /* ---------- Footer ---------- */
+  .footer { border-top: 1px solid var(--border); padding-block: clamp(3rem, 6vw, 5rem); margin-top: 2rem; }
+  .footer-grid { display: flex; flex-wrap: wrap; gap: 2.5rem; justify-content: space-between; align-items: flex-start; }
+  .footer .cta-line { font-size: clamp(1.6rem, 4vw, 2.6rem); font-weight: 600; letter-spacing: -0.03em; line-height: 1.05; max-width: 14ch; margin: 0; }
+  .footer-links { display: flex; flex-direction: column; gap: 0.55rem; }
+  .footer-links a, .footer-links button {
+    color: var(--text-2); font-size: 0.95rem; width: fit-content; transition: color 0.25s;
+    background: none; border: none; padding: 0; cursor: pointer; text-align: left; font-family: inherit;
+  }
+  .footer-links a:hover, .footer-links button:hover { color: var(--accent); }
+  .footer-meta { font-family: var(--font-mono); font-size: 0.75rem; color: var(--text-3); }
+  .footer-head { font-family: var(--font-mono); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-3); margin-bottom: 0.9rem; }
+  .footer-bottom { display: flex; justify-content: space-between; gap: 1rem; flex-wrap: wrap; margin-top: clamp(2.5rem, 5vw, 4rem); padding-top: 1.5rem; border-top: 1px solid var(--border); }
+
+  /* ---------- Reveal animation ---------- */
+  .reveal { transition: opacity 0.9s var(--ease), transform 0.9s var(--ease); }
+  .reveal:not(.in) { opacity: 0; transform: translateY(26px); }
+  .reveal.in { opacity: 1; transform: none; }
+  .reveal[data-delay="1"] { transition-delay: 0.08s; }
+  .reveal[data-delay="2"] { transition-delay: 0.16s; }
+  .reveal[data-delay="3"] { transition-delay: 0.24s; }
+  .reveal[data-delay="4"] { transition-delay: 0.32s; }
+  .reveal[data-delay="5"] { transition-delay: 0.40s; }
+
+  /* ---------- Pills / tags ---------- */
+  .tag {
+    font-family: var(--font-mono); font-size: 0.76rem; font-weight: 450;
+    color: var(--text-2); padding: 0.34rem 0.7rem;
+    border: 1px solid var(--border); border-radius: 999px; background: var(--surface);
+    transition: border-color 0.25s, color 0.25s, background 0.25s;
+  }
+  .tag:hover { border-color: var(--accent); color: var(--accent); }
+  .tag-row { display: flex; flex-wrap: wrap; gap: 0.5rem; }
+
+  /* ---------- Status dot ---------- */
+  .status {
+    display: inline-flex; align-items: center; gap: 0.5rem;
+    font-family: var(--font-mono); font-size: 0.78rem; color: var(--text-2);
+  }
+  .status .dot { width: 8px; height: 8px; border-radius: 50%; background: oklch(0.72 0.17 150); position: relative; }
+  .status .dot::after {
+    content: ""; position: absolute; inset: -4px; border-radius: 50%;
+    background: oklch(0.72 0.17 150 / 0.4); animation: ping 2s ease-out infinite;
+  }
+  @keyframes ping { 0% { transform: scale(0.6); opacity: 0.8; } 100% { transform: scale(2.4); opacity: 0; } }
+
+  /* ---------- Mobile menu ---------- */
+  @media (max-width: 760px) {
+    .nav-links {
+      position: fixed; inset: 0 0 0 auto; width: min(80vw, 320px);
+      flex-direction: column; align-items: flex-start; justify-content: center;
+      gap: 0.5rem; padding: 2rem;
+      background: var(--surface); border-left: 1px solid var(--border);
+      transform: translateX(100%); transition: transform 0.45s var(--ease); z-index: 200;
     }
-  }
-
-  h4 {
-    font-weight: ${theme.fontWeights.semibold};
-    font-size: ${theme.fontSizes.lg};
-    margin: 0;
-  }
-
-  @media (prefers-color-scheme: dark) {
-    h4 {
-      color: ${theme.colors.white};
+    .nav-links.open { transform: none; }
+    .nav-link { font-size: 1.4rem; padding: 0.6rem 0; }
+    .menu-btn {
+      display: grid; place-items: center; width: 38px; height: 38px;
+      border-radius: 999px; border: 1px solid var(--border-2); background: var(--surface);
+      cursor: pointer; color: var(--text); z-index: 210;
     }
+    .menu-btn svg { width: 18px; height: 18px; }
   }
 
-  h5 {
-    font-weight: ${theme.fontWeights.semibold};
-    font-size: ${theme.fontSizes.base};
-    margin: 0;
+  /* ============ HERO ============ */
+  .hero {
+    position: relative;
+    min-height: clamp(620px, 92vh, 940px);
+    display: flex;
+    align-items: center;
+    overflow: hidden;
+  }
+  .hero-canvas-host { position: absolute; inset: 0; z-index: 0; }
+  #hero-canvas { width: 100%; height: 100%; display: block; }
+  .hero-fade {
+    position: absolute; inset: 0; z-index: 1; pointer-events: none;
+    background:
+      radial-gradient(80% 60% at 50% 38%, transparent 0%, var(--bg) 78%),
+      linear-gradient(to bottom, transparent 60%, var(--bg) 100%);
+  }
+  .hero-inner { position: relative; z-index: 2; text-align: center; display: flex; flex-direction: column; align-items: center; }
+  .status.hero-status {
+    padding: 0.5rem 0.95rem; border: 1px solid var(--border-2); border-radius: 999px;
+    background: color-mix(in oklch, var(--surface) 60%, transparent);
+    backdrop-filter: blur(6px); margin-bottom: 2rem;
+  }
+  .hero-name { margin: 0; }
+  .hero-role { font-size: clamp(1.1rem, 2.4vw, 1.65rem); font-weight: 450; color: var(--text); margin: 1.4rem 0 0; letter-spacing: -0.02em; }
+  .hero-lead { margin: 1.5rem auto 0; }
+  .hero-actions { display: flex; gap: 0.8rem; margin-top: 2.4rem; flex-wrap: wrap; justify-content: center; }
+  .hero-scroll {
+    position: absolute; bottom: 2rem; left: 50%; transform: translateX(-50%);
+    z-index: 2; display: flex; flex-direction: column; align-items: center; gap: 0.6rem;
+    font-family: var(--font-mono); font-size: 0.68rem; letter-spacing: 0.15em; color: var(--text-3);
+  }
+  .hero-scroll .line { width: 1px; height: 38px; background: linear-gradient(var(--text-3), transparent); animation: scrolldrop 2.2s var(--ease) infinite; }
+  @keyframes scrolldrop { 0% { transform: scaleY(0); transform-origin: top; } 45% { transform: scaleY(1); transform-origin: top; } 55% { transform: scaleY(1); transform-origin: bottom; } 100% { transform: scaleY(0); transform-origin: bottom; } }
+
+  /* ============ MARQUEE ============ */
+  .marquee {
+    border-block: 1px solid var(--border);
+    padding-block: 1.1rem; overflow: hidden;
+    -webkit-mask-image: linear-gradient(90deg, transparent, #000 12%, #000 88%, transparent);
+            mask-image: linear-gradient(90deg, transparent, #000 12%, #000 88%, transparent);
+  }
+  .marquee-track {
+    display: flex; align-items: center; gap: 2rem; width: max-content;
+    animation: marquee 38s linear infinite;
+    font-family: var(--font-mono); font-size: 1rem; color: var(--text-2); white-space: nowrap;
+  }
+  .marquee-track .sep { color: var(--accent); }
+  @keyframes marquee { to { transform: translateX(-50%); } }
+
+  /* ============ ABOUT ============ */
+  .about-grid { display: grid; grid-template-columns: 1fr 1fr; gap: clamp(2rem, 6vw, 5rem); align-items: start; }
+  .about-left { position: sticky; top: 90px; }
+  .about-left .section-title { margin: 1.2rem 0 2rem; }
+  .about-portrait { overflow: hidden; border-radius: var(--radius-lg); aspect-ratio: 4/5; }
+  .about-portrait img { width: 100%; height: 100%; object-fit: cover; filter: grayscale(1) contrast(1.02); transition: filter 0.6s var(--ease), transform 0.8s var(--ease); }
+  .about-portrait:hover img { filter: grayscale(0); transform: scale(1.03); }
+  .about-right { padding-top: 2.6rem; display: flex; flex-direction: column; gap: 1.4rem; }
+  .about-body { color: var(--text-2); font-size: 1.05rem; line-height: 1.7; max-width: 52ch; margin: 0; }
+  .about-stats { display: flex; gap: 2.5rem; margin-top: 1.4rem; flex-wrap: wrap; }
+  .stat { display: flex; flex-direction: column; gap: 0.2rem; }
+  .stat .num { font-size: 2.4rem; font-weight: 600; letter-spacing: -0.03em; }
+  .stat .lbl { font-family: var(--font-mono); font-size: 0.74rem; color: var(--text-3); text-transform: uppercase; letter-spacing: 0.05em; }
+
+  /* ============ section helpers ============ */
+  section.alt { background: var(--bg-2); border-block: 1px solid var(--border); }
+  .sec-head { margin-bottom: clamp(2.5rem, 5vw, 4rem); }
+  .sec-head .section-title { margin-top: 1rem; }
+
+  /* ============ CAPABILITIES ============ */
+  .cap-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 1.2rem; }
+  .cap-card { padding: clamp(1.6rem, 3vw, 2.4rem); display: flex; flex-direction: column; gap: 1rem; position: relative; overflow: hidden; }
+  .cap-card::before {
+    content: ""; position: absolute; inset: 0; opacity: 0;
+    background: radial-gradient(120% 90% at 0% 0%, var(--accent-soft), transparent 60%);
+    transition: opacity 0.5s var(--ease);
+  }
+  .cap-card:hover { transform: translateY(-4px); box-shadow: var(--shadow-md); border-color: var(--accent); }
+  .cap-card:hover::before { opacity: 1; }
+  .cap-card > * { position: relative; }
+  .cap-num { font-family: var(--font-mono); font-size: 0.8rem; color: var(--accent); letter-spacing: 0.05em; }
+  .cap-card h3 { font-size: 1.4rem; letter-spacing: -0.02em; font-weight: 600; margin: 0; }
+  .cap-card p { color: var(--text-2); font-size: 1rem; line-height: 1.6; flex: 1; margin: 0; }
+
+  /* ============ WORK LIST ============ */
+  .work-list { border-top: 1px solid var(--border); }
+  .work-row {
+    display: grid; grid-template-columns: auto 1fr auto auto; align-items: center; gap: 1.5rem;
+    padding: clamp(1.4rem, 3vw, 2.1rem) 0.5rem; border-bottom: 1px solid var(--border);
+    transition: padding 0.4s var(--ease), background 0.4s var(--ease); position: relative;
+  }
+  .work-row::after { content: ""; position: absolute; left: 0; bottom: -1px; height: 1px; width: 0; background: var(--accent); transition: width 0.5s var(--ease); }
+  .work-row:hover { padding-left: 1.4rem; }
+  .work-row:hover::after { width: 100%; }
+  .work-idx { font-family: var(--font-mono); font-size: 0.82rem; color: var(--text-3); }
+  .work-main h3 { font-size: clamp(1.3rem, 2.6vw, 1.9rem); letter-spacing: -0.02em; transition: color 0.3s; font-weight: 600; margin: 0; }
+  .work-row:hover .work-main h3 { color: var(--accent); }
+  .work-main p { color: var(--text-2); font-size: 0.98rem; margin: 0.3rem 0 0; }
+  .work-tags { display: flex; gap: 0.5rem; flex-wrap: wrap; justify-content: flex-end; max-width: 280px; }
+  .work-arrow { font-size: 1.3rem; color: var(--text-3); transition: transform 0.4s var(--ease), color 0.3s; }
+  .work-row:hover .work-arrow { transform: translateX(6px); color: var(--accent); }
+
+  /* ============ ASSISTANT TEASER ============ */
+  .assistant-card { display: grid; grid-template-columns: 1.1fr 1fr; gap: clamp(2rem, 5vw, 4rem); padding: clamp(2rem, 5vw, 4rem); align-items: center; }
+  .assistant-copy .section-title { margin: 1rem 0 1.2rem; }
+  .assistant-copy .lead { margin-bottom: 2rem; }
+  .assistant-preview { display: flex; flex-direction: column; gap: 0.9rem; padding: 1.6rem; border-radius: var(--radius); background: var(--bg); border: 1px solid var(--border); }
+  .chat-bubble { padding: 0.85rem 1.1rem; border-radius: 14px; font-size: 0.95rem; line-height: 1.5; max-width: 92%; }
+  .chat-bubble.user { align-self: flex-end; background: var(--accent); color: oklch(0.99 0 0); border-bottom-right-radius: 5px; }
+  [data-theme="dark"] .chat-bubble.user { color: oklch(0.16 0.01 264); }
+  .chat-bubble.bot { align-self: flex-start; background: var(--surface); border: 1px solid var(--border); color: var(--text); border-bottom-left-radius: 5px; display: flex; gap: 0.7rem; align-items: flex-start; }
+  .bot-avatar { flex-shrink: 0; width: 26px; height: 26px; border-radius: 7px; background: var(--text); color: var(--bg); font-family: var(--font-mono); font-size: 0.7rem; display: grid; place-items: center; }
+  .chat-typing { align-self: flex-start; display: flex; gap: 5px; padding: 0.7rem 1rem; background: var(--surface); border: 1px solid var(--border); border-radius: 14px; border-bottom-left-radius: 5px; }
+  .chat-typing span { width: 7px; height: 7px; border-radius: 50%; background: var(--text-3); animation: typing 1.4s ease-in-out infinite; }
+  .chat-typing span:nth-child(2) { animation-delay: 0.2s; }
+  .chat-typing span:nth-child(3) { animation-delay: 0.4s; }
+  @keyframes typing { 0%, 60%, 100% { transform: translateY(0); opacity: 0.4; } 30% { transform: translateY(-5px); opacity: 1; } }
+
+  /* ============ HOME RESPONSIVE ============ */
+  @media (max-width: 880px) {
+    .about-grid { grid-template-columns: 1fr; }
+    .about-left { position: static; }
+    .about-right { padding-top: 0; }
+    .cap-grid { grid-template-columns: 1fr; }
+    .assistant-card { grid-template-columns: 1fr; }
+    .work-row { grid-template-columns: auto 1fr auto; }
+    .work-tags { display: none; }
+  }
+  @media (max-width: 520px) {
+    .about-stats { gap: 1.6rem; }
+    .stat .num { font-size: 1.9rem; }
   }
 
-  @media (prefers-color-scheme: dark) {
-    h5 {
-      color: ${theme.colors.white};
-    }
+  /* ============ CV PAGE ============ */
+  .cv-header { padding-top: clamp(3rem, 7vw, 6rem); padding-bottom: clamp(2rem, 4vw, 3rem); }
+  .cv-header .kicker { margin-bottom: 1.4rem; }
+  .cv-name { font-size: clamp(2.6rem, 7vw, 5rem); font-weight: 600; letter-spacing: -0.04em; line-height: 0.98; margin: 0; }
+  .cv-role { font-size: clamp(1.1rem, 2.2vw, 1.5rem); color: var(--text-2); margin: 0.8rem 0 0; font-weight: 400; }
+  .cv-actions { display: flex; gap: 0.8rem; margin-top: 1.8rem; flex-wrap: wrap; }
+
+  .cv-layout { display: grid; grid-template-columns: 1fr 320px; gap: clamp(2rem, 5vw, 4.5rem); align-items: start; padding-bottom: clamp(4rem, 8vw, 7rem); }
+  .cv-main { display: flex; flex-direction: column; gap: clamp(3rem, 6vw, 5rem); min-width: 0; }
+  .cv-block .cv-block-title { display: flex; align-items: baseline; gap: 1rem; margin-bottom: 2rem; }
+  .cv-block-title h2 { font-size: clamp(1.4rem, 3vw, 1.9rem); letter-spacing: -0.02em; font-weight: 600; margin: 0; }
+  .cv-block-title .count { font-family: var(--font-mono); font-size: 0.8rem; color: var(--text-3); }
+  .cv-summary { font-size: 1.1rem; line-height: 1.7; color: var(--text-2); max-width: 60ch; margin: 0; }
+
+  .timeline { position: relative; padding-left: 1.8rem; }
+  .timeline::before { content: ""; position: absolute; left: 5px; top: 6px; bottom: 6px; width: 1px; background: var(--border); }
+  .tl-item { position: relative; padding-bottom: 2.6rem; }
+  .tl-item:last-child { padding-bottom: 0; }
+  .tl-item::before {
+    content: ""; position: absolute; left: -1.8rem; top: 6px; width: 11px; height: 11px; border-radius: 50%;
+    background: var(--bg); border: 2px solid var(--border-2); transition: border-color 0.3s, background 0.3s;
+  }
+  .tl-item:hover::before, .tl-item.current::before { border-color: var(--accent); background: var(--accent); }
+  .tl-meta { font-family: var(--font-mono); font-size: 0.76rem; color: var(--text-3); letter-spacing: 0.03em; display: flex; gap: 0.7rem; align-items: center; flex-wrap: wrap; }
+  .tl-meta .now { color: var(--accent); }
+  .tl-role { font-size: 1.2rem; font-weight: 600; letter-spacing: -0.01em; margin-top: 0.5rem; }
+  .tl-role .at { color: var(--text-2); font-weight: 400; }
+  .tl-desc { color: var(--text-2); margin-top: 0.5rem; line-height: 1.65; max-width: 56ch; font-size: 0.98rem; }
+  .tl-tags { margin-top: 0.9rem; }
+
+  .edu-item { padding: 1.4rem 0; border-top: 1px solid var(--border); }
+  .edu-item:first-child { border-top: none; padding-top: 0; }
+  .edu-q { font-size: 1.15rem; font-weight: 600; letter-spacing: -0.01em; }
+  .edu-place { color: var(--text-2); margin-top: 0.2rem; }
+  .edu-years { font-family: var(--font-mono); font-size: 0.78rem; color: var(--text-3); margin-top: 0.4rem; }
+
+  .cv-side { position: sticky; top: 88px; display: flex; flex-direction: column; gap: 1.2rem; }
+  .side-card { padding: 1.5rem; }
+  .side-photo { padding: 0; overflow: hidden; }
+  .side-photo img { width: 100%; aspect-ratio: 1/1; object-fit: cover; object-position: center 22%; }
+  .side-head { font-family: var(--font-mono); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-3); margin-bottom: 1rem; }
+  .side-contact { display: flex; flex-direction: column; gap: 0.7rem; }
+  .side-contact a, .side-contact span { display: flex; gap: 0.6rem; align-items: center; color: var(--text); font-size: 0.92rem; transition: color 0.25s; }
+  .side-contact a:hover { color: var(--accent); }
+  .side-contact .ico { color: var(--text-3); flex-shrink: 0; }
+  .side-contact svg { width: 15px; height: 15px; }
+
+  .skill-group { margin-bottom: 1.3rem; }
+  .skill-group:last-child { margin-bottom: 0; }
+  .skill-group h4 { font-size: 0.85rem; font-weight: 600; color: var(--text); margin: 0 0 0.7rem; }
+  .lang-row { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.8rem; }
+  .lang-row:last-child { margin-bottom: 0; }
+  .lang-row .lvl { font-family: var(--font-mono); font-size: 0.72rem; color: var(--text-3); }
+  .lang-bar { height: 4px; border-radius: 999px; background: var(--border); margin-top: 0.4rem; overflow: hidden; }
+  .lang-bar span { display: block; height: 100%; background: var(--accent); border-radius: 999px; }
+  .hobby-row { display: flex; flex-wrap: wrap; gap: 0.5rem; }
+
+  @media (max-width: 900px) {
+    .cv-layout { grid-template-columns: 1fr; }
+    .cv-side { position: static; flex-direction: column; }
+    .side-photo { max-width: 280px; }
   }
 
-  a {
-    color: ${theme.colors.blue[600]};
-    text-decoration: underline;
+  @media print {
+    .nav, .footer, .cv-actions, .hero-scroll { display: none !important; }
+    body { background: #fff; color: #000; }
+    .cv-side { position: static; }
   }
 
-  @media (prefers-color-scheme: dark) {
-    a {
-      color: ${theme.colors.blue[300]};
-    }
+  /* ============ CONTACT PAGE ============ */
+  .contact-page { padding-top: clamp(3rem, 7vw, 6rem); padding-bottom: clamp(4rem, 8vw, 7rem); }
+  .contact-grid { display: grid; grid-template-columns: 0.85fr 1.15fr; gap: clamp(2.5rem, 6vw, 5rem); align-items: start; }
+
+  .contact-left .kicker { margin-bottom: 1.4rem; }
+  .contact-left h1 { font-size: clamp(2.4rem, 6vw, 4rem); font-weight: 600; letter-spacing: -0.04em; line-height: 1; margin: 0; }
+  .contact-left .lead { margin-top: 1.4rem; }
+  .contact-status {
+    display: inline-flex; align-items: center; gap: 0.6rem; margin-top: 2rem;
+    font-family: var(--font-mono); font-size: 0.8rem; color: var(--text-2);
+    border: 1px solid var(--border-2); border-radius: 999px; padding: 0.5rem 1rem; background: var(--surface);
+  }
+  .contact-status .dot { width: 8px; height: 8px; border-radius: 50%; background: oklch(0.72 0.17 150); }
+
+  .contact-methods { margin-top: 2.5rem; display: flex; flex-direction: column; gap: 0.4rem; }
+  .method {
+    display: flex; align-items: center; gap: 1rem; padding: 1rem 0; border-top: 1px solid var(--border);
+    color: var(--text); transition: padding 0.3s var(--ease);
+  }
+  .method:hover { padding-left: 0.6rem; }
+  .method .m-ico { width: 38px; height: 38px; border-radius: 11px; border: 1px solid var(--border); display: grid; place-items: center; color: var(--text-2); flex-shrink: 0; transition: border-color 0.3s, color 0.3s; }
+  .method:hover .m-ico { border-color: var(--accent); color: var(--accent); }
+  .method svg { width: 17px; height: 17px; }
+  .method .m-label { font-family: var(--font-mono); font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-3); display: block; }
+  .method .m-value { font-size: 1rem; font-weight: 500; margin-top: 0.1rem; display: block; }
+
+  .contact-form-card { padding: clamp(1.8rem, 4vw, 2.8rem); }
+  .field { margin-bottom: 1.3rem; }
+  .field label { display: block; font-family: var(--font-mono); font-size: 0.74rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-2); margin-bottom: 0.55rem; }
+  .field label .req { color: var(--accent); }
+  .field input, .field textarea {
+    width: 100%; font-family: var(--font-sans); font-size: 1rem; color: var(--text);
+    background: var(--bg); border: 1px solid var(--border-2); border-radius: 12px;
+    padding: 0.85rem 1rem; outline: none; transition: border-color 0.25s, box-shadow 0.25s;
+  }
+  .field input::placeholder, .field textarea::placeholder { color: var(--text-3); }
+  .field input:focus, .field textarea:focus { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
+  .field textarea { resize: vertical; min-height: 130px; line-height: 1.6; }
+  .field.invalid input, .field.invalid textarea { border-color: oklch(0.6 0.2 25); }
+  .field-error { color: oklch(0.62 0.2 25); font-size: 0.8rem; margin-top: 0.4rem; display: none; }
+  .field.invalid .field-error { display: block; }
+  .field-row { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+
+  .form-foot { display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin-top: 0.5rem; flex-wrap: wrap; }
+  .req-note { font-family: var(--font-mono); font-size: 0.74rem; color: var(--text-3); }
+  .req-note .req { color: var(--accent); }
+  .submit-btn { font-size: 1rem; padding: 0.95rem 1.8rem; }
+
+  .form-success {
+    display: none; flex-direction: column; align-items: center; text-align: center;
+    padding: clamp(2.5rem, 6vw, 4rem) 1.5rem; gap: 1rem;
+  }
+  .form-success.show { display: flex; animation: msgIn 0.5s var(--ease) both; }
+  @keyframes msgIn { from { opacity: 0; transform: translateY(12px);} to { opacity: 1; transform: none; } }
+  .success-ring { width: 64px; height: 64px; border-radius: 50%; background: var(--accent-soft); display: grid; place-items: center; color: var(--accent); margin-bottom: 0.5rem; }
+  .success-ring svg { width: 30px; height: 30px; }
+  .form-success h3 { font-size: 1.5rem; letter-spacing: -0.02em; font-weight: 600; margin: 0; }
+  .form-success p { color: var(--text-2); max-width: 38ch; margin: 0; }
+
+  @media (max-width: 860px) {
+    .contact-grid { grid-template-columns: 1fr; }
+    .field-row { grid-template-columns: 1fr; }
   }
 
-  p {
-    font-size: ${theme.fontSizes.base};
-    margin: 0;
-  }
+  /* ============ ASSISTANT PAGE ============ */
+  .asst-wrap { max-width: 820px; margin-inline: auto; padding-inline: var(--gutter); }
+  .asst-page { min-height: calc(100vh - 64px); display: flex; flex-direction: column; padding-top: clamp(2rem, 5vw, 3.5rem); padding-bottom: 2rem; }
 
-  @media (prefers-color-scheme: dark) {
-    p {
-      color: ${theme.colors.white};
-    }
+  .asst-head { text-align: center; margin-bottom: 1.8rem; }
+  .asst-badge {
+    display: inline-flex; align-items: center; gap: 0.5rem; margin-bottom: 1.2rem;
+    font-family: var(--font-mono); font-size: 0.72rem; letter-spacing: 0.05em; text-transform: uppercase;
+    color: var(--text-2); border: 1px solid var(--border-2); border-radius: 999px; padding: 0.4rem 0.85rem;
+    background: var(--surface);
   }
+  .asst-badge .dot { width: 7px; height: 7px; border-radius: 50%; background: oklch(0.72 0.17 150); }
+  .asst-title { font-size: clamp(2rem, 5vw, 3.2rem); font-weight: 600; letter-spacing: -0.035em; margin: 0; }
+  .asst-sub { color: var(--text-2); margin: 0.7rem auto 0; font-size: 1.05rem; max-width: 48ch; }
 
-  svg {
-    fill: currentColor;
-  }
+  .chat { flex: 1; display: flex; flex-direction: column; gap: 1.1rem; padding: 0.5rem 0.2rem 1.5rem; overflow-y: auto; min-height: 260px; }
+  .msg { display: flex; gap: 0.8rem; max-width: 88%; animation: msgIn 0.5s var(--ease) both; }
+  .msg.user { align-self: flex-end; flex-direction: row-reverse; }
+  .msg .avatar { flex-shrink: 0; width: 32px; height: 32px; border-radius: 9px; display: grid; place-items: center; font-family: var(--font-mono); font-size: 0.72rem; font-weight: 600; }
+  .msg.bot .avatar { background: var(--text); color: var(--bg); }
+  .msg.user .avatar { background: var(--accent); color: oklch(0.99 0 0); }
+  [data-theme="dark"] .msg.user .avatar { color: oklch(0.16 0.01 264); }
+  .bubble { padding: 0.85rem 1.15rem; border-radius: 16px; font-size: 0.98rem; line-height: 1.6; }
+  .msg.bot .bubble { background: var(--surface); border: 1px solid var(--border); border-top-left-radius: 5px; color: var(--text); }
+  .msg.user .bubble { background: var(--accent); color: oklch(0.99 0 0); border-top-right-radius: 5px; }
+  [data-theme="dark"] .msg.user .bubble { color: oklch(0.16 0.01 264); }
+  .bubble p { margin: 0; }
+  .bubble p + p { margin-top: 0.6rem; }
+  .bubble a { color: inherit; text-decoration: underline; text-underline-offset: 2px; }
 
-  @media (prefers-color-scheme: dark) {
-    svg {
-      color: ${theme.colors.white};
-    }
-  }
+  .typing { display: flex; gap: 5px; padding: 0.95rem 1.15rem; background: var(--surface); border: 1px solid var(--border); border-radius: 16px; border-top-left-radius: 5px; width: fit-content; }
+  .typing span { width: 7px; height: 7px; border-radius: 50%; background: var(--text-3); animation: typing 1.4s ease-in-out infinite; }
+  .typing span:nth-child(2) { animation-delay: 0.2s; }
+  .typing span:nth-child(3) { animation-delay: 0.4s; }
 
-  label, input, textarea, button {
-    @media (prefers-color-scheme: dark) {
-      color: ${theme.colors.white};
-    }
+  .suggest { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 1rem; }
+  .suggest-chip {
+    font-size: 0.88rem; color: var(--text); background: var(--surface); border: 1px solid var(--border);
+    border-radius: 999px; padding: 0.55rem 1rem; cursor: pointer;
+    transition: border-color 0.25s, color 0.25s, transform 0.25s, background 0.25s;
   }
+  .suggest-chip:hover:not(:disabled) { border-color: var(--accent); color: var(--accent); transform: translateY(-2px); }
+  .suggest-chip:disabled { opacity: 0.5; cursor: not-allowed; }
 
-  input, textarea {
-    @media (prefers-color-scheme: dark) {
-      background-color: ${theme.colors.black};
-    }
+  .composer { position: sticky; bottom: 1rem; }
+  .composer-inner {
+    display: flex; align-items: flex-end; gap: 0.6rem; padding: 0.55rem 0.55rem 0.55rem 1.1rem;
+    background: var(--surface); border: 1px solid var(--border-2); border-radius: 20px;
+    box-shadow: var(--shadow-md); transition: border-color 0.25s;
   }
-
-  ::-webkit-calendar-picker-indicator {
-    filter: invert(1);
+  .composer-inner:focus-within { border-color: var(--accent); }
+  .composer textarea {
+    flex: 1; border: none; background: transparent; resize: none; outline: none;
+    font-family: var(--font-sans); font-size: 1rem; color: var(--text); line-height: 1.5;
+    max-height: 140px; padding: 0.55rem 0;
   }
-
-  code {
-    font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-      monospace;
+  .composer textarea::placeholder { color: var(--text-3); }
+  .send-btn {
+    flex-shrink: 0; width: 42px; height: 42px; border-radius: 13px; border: none; cursor: pointer;
+    background: var(--accent); color: oklch(0.99 0 0); display: grid; place-items: center;
+    transition: background 0.25s, transform 0.25s, opacity 0.25s;
   }
-
-  *, *::before, *::after {
-    box-sizing: border-box;
-  }
+  [data-theme="dark"] .send-btn { color: oklch(0.16 0.01 264); }
+  .send-btn:hover:not(:disabled) { background: var(--accent-2); transform: scale(1.05); }
+  .send-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+  .send-btn svg { width: 18px; height: 18px; }
+  .composer-meta { display: flex; justify-content: space-between; align-items: center; margin-top: 0.6rem; padding-inline: 0.4rem; }
+  .composer-meta span { font-family: var(--font-mono); font-size: 0.72rem; color: var(--text-3); }
+  .composer-meta .disclaimer { color: var(--text-3); }
 `;

--- a/src/styles/GlobalStyles.ts
+++ b/src/styles/GlobalStyles.ts
@@ -226,6 +226,34 @@ export const GlobalStyles = createGlobalStyle`
 
   .menu-btn { display: none; background: none; border: none; }
 
+  /* ---------- Mobile slide-out drawer ---------- */
+  .nav-drawer { display: none; }
+  .nav-drawer-backdrop {
+    position: fixed; inset: 0; z-index: 200;
+    background: oklch(0 0 0 / 0.45);
+    opacity: 0; pointer-events: none; transition: opacity 0.45s var(--ease);
+  }
+  .nav-drawer.open .nav-drawer-backdrop { opacity: 1; pointer-events: auto; }
+  .nav-drawer-panel {
+    position: fixed; top: 0; right: 0; bottom: 0; z-index: 210;
+    width: min(80vw, 320px);
+    display: flex; flex-direction: column; align-items: flex-start;
+    justify-content: center; gap: 0.5rem; padding: 2rem;
+    background: var(--surface); border-left: 1px solid var(--border);
+    box-shadow: var(--shadow-lg);
+    transform: translateX(100%);
+    transition: transform 0.45s var(--ease);
+  }
+  .nav-drawer.open .nav-drawer-panel { transform: none; }
+  .nav-drawer-panel .nav-link { font-size: 1.4rem; padding: 0.6rem 0; color: var(--text); }
+  .nav-drawer-close {
+    position: absolute; top: 1.1rem; right: 1.1rem;
+    width: 38px; height: 38px; border-radius: 999px;
+    border: 1px solid var(--border-2); background: var(--surface);
+    display: grid; place-items: center; cursor: pointer; color: var(--text);
+  }
+  .nav-drawer-close svg { width: 18px; height: 18px; }
+
   /* ---------- Cards / surfaces ---------- */
   .card {
     background: var(--surface);
@@ -283,19 +311,13 @@ export const GlobalStyles = createGlobalStyle`
 
   /* ---------- Mobile menu ---------- */
   @media (max-width: 760px) {
-    .nav-links {
-      position: fixed; inset: 0 0 0 auto; width: min(80vw, 320px);
-      flex-direction: column; align-items: flex-start; justify-content: center;
-      gap: 0.5rem; padding: 2rem;
-      background: var(--surface); border-left: 1px solid var(--border);
-      transform: translateX(100%); transition: transform 0.45s var(--ease); z-index: 200;
-    }
-    .nav-links.open { transform: none; }
-    .nav-link { font-size: 1.4rem; padding: 0.6rem 0; }
+    /* hide the inline desktop links; use the slide-out drawer instead */
+    .nav-links { display: none; }
+    .nav-drawer { display: block; }
     .menu-btn {
       display: grid; place-items: center; width: 38px; height: 38px;
       border-radius: 999px; border: 1px solid var(--border-2); background: var(--surface);
-      cursor: pointer; color: var(--text); z-index: 210;
+      cursor: pointer; color: var(--text);
     }
     .menu-btn svg { width: 18px; height: 18px; }
   }


### PR DESCRIPTION
## Summary

Implements the [Claude Design](https://claude.ai/design) handoff — a portfolio redesign the user called **"Precision / AI"**: Apple-grade restraint (lots of whitespace, hairline detail, precise type) with a quiet AI/futuristic edge (electric-blue accent, subtle motion & glow). The HTML/CSS/JS prototype was recreated as **React + styled-components** on top of `develop`, preserving all existing functionality (Firebase data, owner CRUD, the live AI assistant API).

## What changed

**Design system** (`src/styles/GlobalStyles.ts`)
- Ported the prototype's token set (OKLCH monochrome base + electric-blue accent), shared primitives (`.btn`, `.card`, `.tag`, `.kicker`, reveals…) and all page CSS.
- Light/dark toggle via a `data-theme` attribute on `<html>` (`src/contexts/ThemeModeContext.tsx`), persisted to `localStorage`, with a no-flash init script and Geist / Geist Mono fonts added in `public/index.html`.

**Shared shell**
- `Navbar` — sticky blurred nav with active-link dot, theme toggle, "Work with me" CTA and a mobile menu (replaces the old `PageNavigatorBar` in the layout). Keeps the existing `SkipLink` + focus-management for accessibility.
- `PortfolioFooter` — full (CTA + navigation) and minimal variants; surfaces owner-only Developer Tools / Messages / Logout links when authenticated.
- `HeroCanvas` (interactive dot-grid) and a `useScrollReveal` hook port the prototype's `hero.js` / `app.js` behaviours.

**Pages**
- **Home** — animated hero, company marquee, about + portrait, capability cards, selected-work list, assistant teaser, CTA footer. (`/` now renders this instead of `NewHomePageLayout`.)
- **CV** — career timeline, education and sidebar (photo, contact, skills, languages, hobbies). **Kept live Firebase data and the full owner CRUD** for experiences / education / skill-sets, including all popups.
- **Contact** — two-column layout with inline per-field validation and a success state; **still posts to Firebase** (`database.messages`).
- **Assistant** — reskinned chat (status badge, message bubbles, suggestion chips, sticky composer) while preserving the existing conversation API wiring. Suggestion chips prefill the composer (the send handler reads message state from its closure).

## Notes
- LinkedIn links point to `linkedin.com/in/danielaboo` and the CV timeline reflects live Firebase data — let me know any corrections.
- `NewHomePageLayout`, the old `PageNavigatorBar`/`Footer` and `AskmeAnything.styles.ts` are left in place (now unused) rather than deleted, to keep the diff focused; happy to remove them.

## Verification
- `npx tsc --noEmit` — passes
- `react-scripts build` — compiles successfully, no warnings

Draft for review.

---
_Generated by [Claude Code](https://claude.ai/code/session_013zWVtcCDBccU7Psh2xnaSM)_